### PR TITLE
Add Rails 8 gem to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,11 @@
 
 source "https://rubygems.org"
 
+# Rails 8 gem
 gem 'rails', '~> 8.0.0'
- gem 'pg'
- gem 'puma'
- gem 'sass-rails', '>= 6'
- gem 'importmap-rails'
- gem 'turbo-rails'
- gem 'stimulus-rails'
+gem 'pg'
+gem 'puma'
+gem 'sass-rails', '>= 6'
+gem 'importmap-rails'
+gem 'turbo-rails'
+gem 'stimulus-rails'


### PR DESCRIPTION
## Summary
- ensure Rails 8 gem is present in Gemfile
- clean up indentation

## Testing
- `bundle exec rake test` *(fails: Could not find gem 'rails (~> 8.0.0)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_684f59478180832ab837e3f1f2d44e7a