### PR TITLE
Allow Ruby 3.2.2 or newer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENT Instructions
+
+This repository is a Rails 8.0 project.
+
+## Development Environment
+
+- The project supports Ruby **3.2.2 or newer**. Ensure compatibility with
+  **Ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [arm64-darwin24]**.
+- `.ruby-version` currently specifies Ruby 3.2.2. Bundler allows newer versions.
+- Keep code in standard Ruby style (two-space indentation, no trailing spaces).
+
+## Contributing
+
+1. After making changes, run `bundle exec rake -T | head` to verify Rake tasks
+   load. If the command fails due to missing Ruby versions, mention it in the
+   Testing section.
+2. Commit with clear messages.
+3. Cite modified lines in PR summaries.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-ruby "3.2.2"
+ruby ">= 3.2.2"
 
 gem 'rails', '~> 8.0.0'
  gem 'pg'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ TongXin (\u201cOne Heart\u201d) is a minimal social media application built with
 
 ## Setup
 
-1. Install Ruby (3.2+ required) and Bundler.
+1. Install Ruby 3.2.2 or newer and Bundler.
 2. Install Rails 8 (e.g., `gem install rails -v 8.0.0`).
 3. Run `bundle install` to install dependencies.
 4. Create and migrate the database:


### PR DESCRIPTION
## Summary
- support Ruby versions >= 3.2.2 instead of pinning to 3.4.4
- update Gemfile and `.ruby-version`
- refresh setup instructions in README

## Testing
- `bundle exec rake -T | head` *(fails: rbenv: version `3.2.2' is not installed)*


------
https://chatgpt.com/codex/tasks/task_e_684f5c7b86fc832ab23b99939cead0e4