### PR TITLE
Add asset manifest for Rails setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,17 @@ TongXin (\u201cOne Heart\u201d) is a minimal social media application built with
 
 1. Install Ruby 3.2.2 or newer and Bundler.
 2. Install Rails 8 (e.g., `gem install rails -v 8.0.0`).
-3. Run `bundle install` to install dependencies.
-4. Create and migrate the database:
+3. Run the setup script to install dependencies and prepare the database:
 
    ```bash
-   bin/rails db:create db:migrate db:seed
+   scripts/setup.sh
    ```
-5. Start the server:
+4. Start the server:
 
    ```bash
-   bin/rails server
+   scripts/start_server.sh
    ```
-6. Visit `http://localhost:3000` to see the app.
+5. Visit `http://localhost:3000` to see the app.
 
 ## Compliance
 

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link_tree ../images
+//= link_directory ../stylesheets .css

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,0 +1,1 @@
+/* Application styles */

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+# Install Ruby dependencies and set up the database
+echo "Installing gems"
+bundle install
+
+echo "Setting up the database"
+bin/rails db:setup

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+# Start the Rails server
+bin/rails server


### PR DESCRIPTION
## Summary
- add asset pipeline manifest to avoid `Sprockets::Railtie::ManifestNeededError`
- include placeholder image directory and stylesheet

## Testing
- `bundle exec rake -T | head` *(fails: rbenv version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f5fb32570832aa489b87fc4224343