### PR TITLE
Fix db setup by adding sqlite3 and eager_load config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,10 @@ source "https://rubygems.org"
 ruby ">= 3.2.2"
 
 gem 'rails', '~> 8.0.0'
- gem 'pg'
- gem 'puma'
- gem 'sass-rails', '>= 6'
- gem 'importmap-rails'
- gem 'turbo-rails'
- gem 'stimulus-rails'
+gem 'pg'
+gem 'sqlite3', group: %i[development test]
+gem 'puma'
+gem 'sass-rails', '>= 6'
+gem 'importmap-rails'
+gem 'turbo-rails'
+gem 'stimulus-rails'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.eager_load = false
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.eager_load = true
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.eager_load = false
+end


### PR DESCRIPTION
## Summary
- add sqlite3 gem for development and test environments
- configure eager load in new development, test, and production environment files

## Testing
- `bundle exec rake -T | head` *(fails: rbenv version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f6939f834832a9c0db18dfb2b076d