### PR TITLE
Fix ApplicationRecord error for db setup

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  primary_abstract_class
+end


### PR DESCRIPTION
## Summary
- add ApplicationRecord base class

## Testing
- `bundle exec rake -T | head` *(fails: version `3.2.2` is not installed)*
- `bundle exec rails db:setup` *(fails: version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f8a797478832a999f5c7f080d8e4c