### PR TITLE
Fix rblade gem name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,6 @@ gem 'bcrypt', '~> 3.1'
 
 # Frontend and templating
 # Switch to rblade templating
-gem 'rblade-rails'
+gem 'rblade'
 # Use Tailwind for a modern design
 gem 'tailwindcss-rails'


### PR DESCRIPTION
## Summary
- switch to `rblade` gem instead of `rblade-rails`

## Testing
- `bundle exec rake -T | head` *(fails: rbenv: version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850564e6d1c832aaa4d3f7f07f4e120