### PR TITLE
Add missing Devise gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,9 @@ gem 'turbo-rails'
 gem 'stimulus-rails'
 gem 'bcrypt', '~> 3.1'
 
+# User authentication
+gem 'devise'
+
 # Frontend and templating
 # Switch to rblade templating
 gem 'rblade'


### PR DESCRIPTION
## Summary
- include the Devise gem for authentication

## Testing
- `RBENV_VERSION=3.4.4 bundle exec rake -T | head` *(fails: Could not find gem 'rails (~> 8.0.0)')*


------
https://chatgpt.com/codex/tasks/task_e_68505d2bd840832ab27769a9759df477