### PR TITLE
Add auto-merge GitHub action

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,22 @@
+name: Auto Approve and Merge
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hmarr/auto-approve-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: peter-evans/merge@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge_method: squash

--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ TongXin (\u201cOne Heart\u201d) is a minimal social media application built with
 
 This project strives to follow applicable regulations and moderation requirements. Content posted by users should comply with local laws and community standards.
 
+
+## Automation
+
+Pull requests targeting `main` are automatically approved and merged using GitHub Actions. The workflow in `.github/workflows/auto-approve.yml` approves the request and squashes the commits once auto-merge is enabled.


### PR DESCRIPTION
## Summary
- automate approvals and merges in GitHub with a new workflow
- document auto-merge behavior in README

## Testing
- `bundle exec rake -T | head` *(fails: version `3.2.2` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68505e1a58ec832a8b6da6cf1c95ed4e