### PR TITLE
Fix Devise initializer

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,4 +1,5 @@
 Devise.setup do |config|
+  require 'devise/orm/active_record'
   config.mailer_sender = 'please-change-me@example.com'
   config.secret_key = 'dummysecretkey'
   config.parent_controller = 'ApplicationController'


### PR DESCRIPTION
## Summary
- load Devise's ActiveRecord integration in `config/initializers/devise.rb`

## Testing
- `bundle exec rake -T | head` *(fails: Could not find gem 'rails (~> 8.0.0)' in locally installed gems)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 'Forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_68505ee536ac832ab2160d73eaafc609