### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Ignore bundler config
+/.bundle
+
+# Ignore log files and temp files
+/log/*
+!/log/.keep
+/tmp
+!/tmp/.keep
+
+# Ignore Rails storage files (Active Storage)
+/storage/*
+!/storage/.keep
+
+# Ignore public asset files
+/public/assets
+
+# Ignore database files
+/db/*.sqlite3
+/db/*.sqlite3-journal
+
+# Ignore credentials, master keys, and environment files
+/config/master.key
+/config/credentials.yml.enc
+.env
+.env.*.local
+
+# Ignore node modules and Yarn files
+/node_modules
+/yarn-error.log
+
+# Ignore Byebug command history
+.byebug_history
+
+# Ignore coverage reports and bundler vendor directory
+/coverage/
+/vendor/bundle
+
+# Ignore Ruby-specific project files
+.ruby-gemset
+.ruby-version


### PR DESCRIPTION
## Summary
- add a Rails-flavored .gitignore so temporary files aren't committed

## Testing
- `bundle exec rake -T | head` *(fails: Could not find gem 'rails (~> 8.0.0)')*

------
https://chatgpt.com/codex/tasks/task_e_68506044958c832a8f5b960d88ac2071