### PR TITLE
Improve UI with Tailwind card styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,14 @@
 /* Application styles */
+
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+  background-color: #f7fafc;
+}
+
+.card {
+  background: #ffffff;
+  padding: 1rem;
+  border-radius: 0.25rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}

--- a/app/views/comments/_comment.html.rbl
+++ b/app/views/comments/_comment.html.rbl
@@ -1,7 +1,7 @@
-<p class="mb-1">
+<div class="border-b pb-2 last:border-b-0">
   <strong><%= "#{comment.user.username}:" %></strong>
   <%= comment.body %>
   <% if current_user == comment.user %>
     <%= link_to 'Delete', [comment.post, comment], method: :delete, data: { confirm: 'Are you sure?' }, class: 'text-red-600 hover:underline ml-2 text-sm' %>
   <% end %>
-</p>
+</div>

--- a/app/views/devise/registrations/new.html.rbl
+++ b/app/views/devise/registrations/new.html.rbl
@@ -1,23 +1,25 @@
-<h1 class="text-2xl font-bold mb-4">Sign Up</h1>
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <div class="space-y-4">
-    <div class="space-y-1">
-      <%= f.label :username, class: 'block text-sm font-medium' %>
-      <%= f.text_field :username, autofocus: true, class: 'border rounded w-full p-2' %>
+<div class="card mb-4">
+  <h1 class="text-2xl font-bold mb-4">Sign Up</h1>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+    <div class="space-y-4">
+      <div class="space-y-1">
+        <%= f.label :username, class: 'block text-sm font-medium' %>
+        <%= f.text_field :username, autofocus: true, class: 'border rounded w-full p-2' %>
+      </div>
+      <div class="space-y-1">
+        <%= f.label :email, class: 'block text-sm font-medium' %>
+        <%= f.email_field :email, class: 'border rounded w-full p-2' %>
+      </div>
+      <div class="space-y-1">
+        <%= f.label :password, class: 'block text-sm font-medium' %>
+        <%= f.password_field :password, autocomplete: 'new-password', class: 'border rounded w-full p-2' %>
+      </div>
+      <div class="space-y-1">
+        <%= f.label :password_confirmation, class: 'block text-sm font-medium' %>
+        <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'border rounded w-full p-2' %>
+      </div>
+      <%= f.submit 'Create Account', class: 'bg-blue-600 text-white px-3 py-1 rounded' %>
     </div>
-    <div class="space-y-1">
-      <%= f.label :email, class: 'block text-sm font-medium' %>
-      <%= f.email_field :email, class: 'border rounded w-full p-2' %>
-    </div>
-    <div class="space-y-1">
-      <%= f.label :password, class: 'block text-sm font-medium' %>
-      <%= f.password_field :password, autocomplete: 'new-password', class: 'border rounded w-full p-2' %>
-    </div>
-    <div class="space-y-1">
-      <%= f.label :password_confirmation, class: 'block text-sm font-medium' %>
-      <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'border rounded w-full p-2' %>
-    </div>
-    <%= f.submit 'Create Account', class: 'bg-blue-600 text-white px-3 py-1 rounded' %>
-  </div>
-<% end %>
+  <% end %>
+</div>
 <%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.rbl
+++ b/app/views/devise/sessions/new.html.rbl
@@ -1,19 +1,21 @@
-<h1 class="text-2xl font-bold mb-4">Login</h1>
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="space-y-4">
-    <div class="space-y-1">
-      <%= f.label :email, class: 'block text-sm font-medium' %>
-      <%= f.email_field :email, autofocus: true, class: 'border rounded w-full p-2' %>
+<div class="card mb-4">
+  <h1 class="text-2xl font-bold mb-4">Login</h1>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <div class="space-y-4">
+      <div class="space-y-1">
+        <%= f.label :email, class: 'block text-sm font-medium' %>
+        <%= f.email_field :email, autofocus: true, class: 'border rounded w-full p-2' %>
+      </div>
+      <div class="space-y-1">
+        <%= f.label :password, class: 'block text-sm font-medium' %>
+        <%= f.password_field :password, autocomplete: 'current-password', class: 'border rounded w-full p-2' %>
+      </div>
+      <div class="flex items-center">
+        <%= f.check_box :remember_me, class: 'mr-2' %>
+        <%= f.label :remember_me, class: 'text-sm' %>
+      </div>
+      <%= f.submit 'Log in', class: 'bg-blue-600 text-white px-3 py-1 rounded' %>
     </div>
-    <div class="space-y-1">
-      <%= f.label :password, class: 'block text-sm font-medium' %>
-      <%= f.password_field :password, autocomplete: 'current-password', class: 'border rounded w-full p-2' %>
-    </div>
-    <div class="flex items-center">
-      <%= f.check_box :remember_me, class: 'mr-2' %>
-      <%= f.label :remember_me, class: 'text-sm' %>
-    </div>
-    <%= f.submit 'Log in', class: 'bg-blue-600 text-white px-3 py-1 rounded' %>
-  </div>
-<% end %>
+  <% end %>
+</div>
 <%= render "devise/shared/links" %>

--- a/app/views/posts/edit.html.rbl
+++ b/app/views/posts/edit.html.rbl
@@ -1,3 +1,5 @@
-<h1 class="text-2xl font-bold mb-4">Edit Post</h1>
-<%= render 'form', post: @post %>
+<div class="card mb-4">
+  <h1 class="text-2xl font-bold mb-4">Edit Post</h1>
+  <%= render 'form', post: @post %>
+</div>
 <%= link_to 'Back', posts_path, class: 'text-blue-600 hover:underline' %>

--- a/app/views/posts/index.html.rbl
+++ b/app/views/posts/index.html.rbl
@@ -1,14 +1,22 @@
-<h1 class="text-2xl font-bold mb-4">Posts</h1>
-<ul class="divide-y divide-gray-200">
-  <% @posts.each do |post| %>
-    <li class="flex justify-between items-center py-2">
-      <span>
-        <%= link_to post.title, post, class: 'text-blue-600 hover:underline' %>
-        <small class="text-gray-500 ml-2">by <%= post.user.username %></small>
-      </span>
-      <% if current_user == post.user %>
-        <%= link_to 'Edit', edit_post_path(post), class: 'text-sm text-blue-600 hover:underline' %>
-      <% end %>
-    </li>
-  <% end %>
-</ul>
+<h1 class="text-3xl font-bold mb-6 text-center">Recent Posts</h1>
+<% if @posts.any? %>
+  <div class="grid gap-4 md:grid-cols-2">
+    <% @posts.each do |post| %>
+      <div class="card">
+        <h2 class="text-xl font-semibold mb-2">
+          <%= link_to post.title, post, class: 'hover:underline' %>
+        </h2>
+        <p class="text-gray-500 text-sm mb-2">by <%= post.user.username %></p>
+        <p class="text-gray-700 mb-4"><%= truncate(post.body, length: 100) %></p>
+        <div class="flex justify-end space-x-2">
+          <% if current_user == post.user %>
+            <%= link_to 'Edit', edit_post_path(post), class: 'text-sm text-blue-600 hover:underline' %>
+          <% end %>
+          <%= link_to 'View', post, class: 'text-sm text-blue-600 hover:underline' %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <p class="text-center text-gray-600">No posts yet.</p>
+<% end %>

--- a/app/views/posts/new.html.rbl
+++ b/app/views/posts/new.html.rbl
@@ -1,3 +1,5 @@
-<h1 class="text-2xl font-bold mb-4">New Post</h1>
-<%= render 'form', post: @post %>
+<div class="card mb-4">
+  <h1 class="text-2xl font-bold mb-4">New Post</h1>
+  <%= render 'form', post: @post %>
+</div>
 <%= link_to 'Back', posts_path, class: 'text-blue-600 hover:underline' %>

--- a/app/views/posts/show.html.rbl
+++ b/app/views/posts/show.html.rbl
@@ -1,18 +1,24 @@
-<h1 class="text-2xl font-bold mb-4"><%= @post.title %></h1>
-<p class="mb-2"><%= @post.body %></p>
-<p class="text-sm text-gray-500 mb-4">Posted by <%= @post.user.username %></p>
-<% if current_user == @post.user %>
-  <%= link_to 'Edit', edit_post_path(@post), class: 'text-blue-600 hover:underline mr-2', data: { turbo: false } %>
-<% end %>
-<%= link_to 'Back', posts_path, class: 'text-blue-600 hover:underline' %>
-
-<h2 class="text-xl font-semibold mt-6 mb-2">Comments</h2>
-<div class="mb-3">
-  <%= render @post.comments %>
+<div class="card">
+  <h1 class="text-2xl font-bold mb-4"><%= @post.title %></h1>
+  <p class="mb-2"><%= simple_format(@post.body) %></p>
+  <p class="text-sm text-gray-500 mb-4">Posted by <%= @post.user.username %></p>
+  <div class="mb-4">
+    <% if current_user == @post.user %>
+      <%= link_to 'Edit', edit_post_path(@post), class: 'text-blue-600 hover:underline mr-2', data: { turbo: false } %>
+    <% end %>
+    <%= link_to 'Back', posts_path, class: 'text-blue-600 hover:underline' %>
+  </div>
 </div>
-<% if current_user %>
-  <%= form_with(model: [@post, Comment.new], class: 'space-y-2') do |form| %>
-    <%= form.text_area :body, class: 'border rounded w-full p-2', rows: 3 %>
-    <%= form.submit 'Add Comment', class: 'bg-blue-600 text-white px-3 py-1 rounded' %>
+
+<div class="card mt-6">
+  <h2 class="text-xl font-semibold mb-2">Comments</h2>
+  <div class="space-y-2 mb-4">
+    <%= render @post.comments %>
+  </div>
+  <% if current_user %>
+    <%= form_with(model: [@post, Comment.new], class: 'space-y-2') do |form| %>
+      <%= form.text_area :body, class: 'border rounded w-full p-2', rows: 3 %>
+      <%= form.submit 'Add Comment', class: 'bg-blue-600 text-white px-3 py-1 rounded' %>
+    <% end %>
   <% end %>
-<% end %>
+</div>

--- a/app/views/users/show.html.rbl
+++ b/app/views/users/show.html.rbl
@@ -1,7 +1,9 @@
-<h1 class="text-2xl font-bold mb-4"><%= @user.username %></h1>
-<p class="mb-2">Email: <%= @user.email %></p>
-<% if current_user == @user %>
-  <%= link_to 'Edit', edit_user_registration_path, class: 'text-blue-600 hover:underline mr-2' %>
-  <%= link_to 'Delete', registration_path(:user), method: :delete, data: { confirm: 'Are you sure?' }, class: 'text-red-600 hover:underline mr-2' %>
-  <%= link_to 'Logout', destroy_user_session_path, method: :delete, class: 'text-blue-600 hover:underline' %>
-<% end %>
+<div class="card">
+  <h1 class="text-2xl font-bold mb-4"><%= @user.username %></h1>
+  <p class="mb-2">Email: <%= @user.email %></p>
+  <% if current_user == @user %>
+    <%= link_to 'Edit', edit_user_registration_path, class: 'text-blue-600 hover:underline mr-2' %>
+    <%= link_to 'Delete', registration_path(:user), method: :delete, data: { confirm: 'Are you sure?' }, class: 'text-red-600 hover:underline mr-2' %>
+    <%= link_to 'Logout', destroy_user_session_path, method: :delete, class: 'text-blue-600 hover:underline' %>
+  <% end %>
+</div>


### PR DESCRIPTION
## Summary
- add custom card and body styles
- display posts in a card grid with truncation and action links
- wrap post detail and comment form in cards
- style comment, user profile, and post forms with cards
- style Devise login and registration pages with cards

## Testing
- `bundle exec rake -T | head` *(fails: Could not find gem 'rails (~> 8.0.0)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_6850612fc554832ab2623056ccaad722