### PR TITLE
Fix asset path in layout

### DIFF
--- a/app/views/layouts/application.html.rbl
+++ b/app/views/layouts/application.html.rbl
@@ -4,7 +4,7 @@
     <title>TongXin</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%= favicon_link_tag 'favicon.ico' %>
+    <%= favicon_link_tag '/favicon.svg', type: 'image/svg+xml' %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbo-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbo-track': 'reload' %>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#ff0000"/>
+</svg>


### PR DESCRIPTION
## Summary
- reference `favicon.svg` from the public folder
- replace binary icon with a small SVG

## Testing
- `bundle exec rake -T | head` *(fails: Could not find gem 'rails (~> 8.0.0)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_685062835524832a8444b318d9617d0a