### PR TITLE
Make llama_cpp optional

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,4 +22,7 @@ gem 'devise'
 gem 'rblade'
 # Use Tailwind for a modern design
 gem 'tailwindcss-rails'
-gem 'llama_cpp'
+
+group :llm do
+  gem 'llama_cpp'
+end

--- a/README.md
+++ b/README.md
@@ -40,8 +40,16 @@ TongXin (\u201cOne Heart\u201d) is a minimal social media application built with
    scripts/start_server.sh
    ```
 6. Visit `http://localhost:3000` to see the app.
-7. To use recommendations, install a local LLM such as `llama_cpp` and set
-   `LLM_MODEL_PATH` to the location of your model file.
+7. The recommendation engine is optional. To enable it, install the `llm`
+   gem group:
+
+   ```bash
+   bundle config set --local without 'production'
+   bundle install --with llm
+   ```
+
+   Then install a local LLM such as `llama_cpp` and set `LLM_MODEL_PATH` to the
+   location of your model file.
 
 ## Compliance
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,9 +2,9 @@
 set -e
 # Install Ruby dependencies and set up the database
 echo "Installing gems"
-# Skip production gems like `pg`. Bundler remembers this via
+# Skip production and optional LLM gems. Bundler remembers this via
 # the local config rather than the deprecated `--without` flag.
-bundle config set --local without 'production'
+bundle config set --local without 'production llm'
 bundle install
 
 echo "Setting up the database"


### PR DESCRIPTION
## Summary
- allow skipping the llama_cpp gem by placing it in the `llm` group
- skip installing this group in the setup script
- document how to enable the optional recommendation engine

## Testing
- `bundle exec rake -T | head` *(fails: Could not find gem 'rails (~> 8.0.0)' in locally installed gems)*
- `bundle install --jobs=4 --retry=3` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_685071fc95b0832aa1fb1b79a113ee52