### PR TITLE
Implement LLM recommendations with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ TongXin (\u201cOne Heart\u201d) is a minimal social media application built with
    scripts/start_server.sh
    ```
 6. Visit `http://localhost:3000` to see the app.
-7. To use recommendations, install a local LLM such as `llama_cpp` and set
-   `LLM_MODEL_PATH` to the location of your model file.
+7. Enter your interests as JSON in the *Interests* field when creating or
+   editing your account (e.g. `{ "keywords": ["rails", "ruby"] }`).
+8. To enable AI recommendations, install a local Llama model using the
+   `llama_cpp` gem and set `LLM_MODEL_PATH` to your model file. If the model
+   can't load, the app falls back to simple keyword matching.
 
 ## Compliance
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,15 @@ class User < ApplicationRecord
 
   serialize :preferences, JSON
 
+  def preferences=(value)
+    parsed = if value.is_a?(String)
+               JSON.parse(value) rescue {}
+             else
+               value || {}
+             end
+    super(parsed)
+  end
+
   validates :username, presence: true, uniqueness: true
   validates :email, presence: true, uniqueness: true
   validates :avatar_url, format: URI::DEFAULT_PARSER.make_regexp(%w[http https]), allow_blank: true

--- a/app/services/llm_post_recommender.rb
+++ b/app/services/llm_post_recommender.rb
@@ -5,18 +5,29 @@ class LlmPostRecommender
   end
 
   def interested?(post)
-    meta = @user.preferences.to_json
+    prefs = @user.preferences
     prompt = <<~TEXT
       The following JSON describes a user's interests:
-      #{meta}
+      #{prefs.to_json}
       Based on these interests, would the user be interested in the post titled "#{post.title}" with body:
       #{post.body}
       Respond with "Yes" or "No".
     TEXT
-    response = @llm.complete(prompt, tokens: 8)
-    response.downcase.include?('yes')
+    if @llm
+      response = @llm.complete(prompt, tokens: 8)
+      return true if response.downcase.include?('yes')
+    end
+    keyword_fallback(prefs, post)
   rescue StandardError => e
     Rails.logger.error("LLM recommendation failed: #{e.message}")
-    false
+    keyword_fallback(prefs, post)
+  end
+
+  private
+
+  def keyword_fallback(prefs, post)
+    keywords = Array(prefs['keywords'] || prefs['interests'] || prefs['topics'])
+    content = "#{post.title} #{post.body}".downcase
+    keywords.any? { |kw| content.include?(kw.downcase) }
   end
 end


### PR DESCRIPTION
## Summary
- parse user preferences JSON on assignment
- fall back to keyword matching when the LLM can't be used
- explain interest JSON and fallback in the README

## Testing
- `bundle exec rake -T | head` *(fails: Could not find gem 'rails (~> 8.0.0)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_6850735d75a8832ab621c84470adf1b5