### PR TITLE
Improve setup script to install llama.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ TongXin (\u201cOne Heart\u201d) is a minimal social media application built with
 1. Install Ruby 3.2.2 or newer and Bundler.
 2. Install Rails 8 (e.g., `gem install rails -v 8.0.0`).
 3. Run the setup script to install dependencies and prepare the database.
-   The script skips production gems (using `bundle config set without 'production'`)
-   so libraries like `pg` aren't required during development:
+   The script now also builds the `llama.cpp` library if needed and performs a
+   quick Rails server check. It still skips production gems (via
+   `bundle config set without 'production'`) so libraries like `pg` aren't
+   required during development:
 
    ```bash
    scripts/setup.sh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,11 +1,33 @@
 #!/bin/bash
 set -e
+
+# Build libllama if the llama_cpp gem's native extension can't
+# find it. This allows the local LLM features to work out of the box.
+if ! ldconfig -p | grep -q libllama; then
+  echo "Building libllama from source"
+  git clone --depth 1 https://github.com/ggerganov/llama.cpp.git /tmp/llama.cpp
+  cmake -S /tmp/llama.cpp -B /tmp/llama.cpp/build -DLLAMA_STATIC=OFF
+  cmake --build /tmp/llama.cpp/build --target llama
+  sudo cp /tmp/llama.cpp/build/bin/libllama.so /usr/local/lib/
+  sudo cp /tmp/llama.cpp/include/llama*.h /usr/local/include/
+  sudo cp /tmp/llama.cpp/ggml/include/*.h /usr/local/include/
+  sudo ldconfig
+fi
+
 # Install Ruby dependencies and set up the database
 echo "Installing gems"
-# Skip production gems like `pg`. Bundler remembers this via
-# the local config rather than the deprecated `--without` flag.
 bundle config set --local without 'production'
+bundle config set --local build.llama_cpp --with-llama-dir=/usr/local
 bundle install
 
 echo "Setting up the database"
 bin/rails db:setup
+
+# Basic sanity check: start and stop the server
+echo "Starting Rails server to verify setup"
+bin/rails server -d -e test
+sleep 5
+if [ -f tmp/pids/server.pid ]; then
+  kill "$(cat tmp/pids/server.pid)"
+fi
+echo "Setup complete"


### PR DESCRIPTION
## Summary
- auto-build `llama.cpp` if libllama is missing
- configure bundler with the libllama path
- start and stop the Rails server as a sanity check
- document the enhanced setup script in README

## Testing
- `bundle install`
- `bundle exec rake -T | head`
- `bin/rails server -d -e test`

------
https://chatgpt.com/codex/tasks/task_e_6850753cee90832ab26c877bd16d19f1