### PR TITLE
Fix build script error

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,7 +6,7 @@ set -e
 if ! ldconfig -p | grep -q libllama; then
   echo "Building libllama from source"
   git clone --depth 1 https://github.com/ggerganov/llama.cpp.git /tmp/llama.cpp
-  cmake -S /tmp/llama.cpp -B /tmp/llama.cpp/build -DLLAMA_STATIC=OFF
+  cmake -S /tmp/llama.cpp -B /tmp/llama.cpp/build -DLLAMA_STATIC=OFF -DLLAMA_CURL=OFF
   cmake --build /tmp/llama.cpp/build --target llama
   sudo cp /tmp/llama.cpp/build/bin/libllama.so /usr/local/lib/
   sudo cp /tmp/llama.cpp/include/llama*.h /usr/local/include/


### PR DESCRIPTION
## Summary
- build libllama without CURL dependency to avoid CMake failure

## Testing
- `bundle exec rake -T | head` *(fails: Could not find gem 'sass-rails (>= 6)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68507ab499f8832a96f497d0fc579f53