### PR TITLE
Fix serialization in user model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,11 @@ class User < ApplicationRecord
   has_many :following, through: :active_follows, source: :followed
   has_many :followers, through: :passive_follows, source: :follower
 
-  serialize :preferences, JSON
+  def preferences
+    raw = super()
+    return {} if raw.blank?
+    JSON.parse(raw) rescue {}
+  end
 
   def preferences=(value)
     parsed = if value.is_a?(String)
@@ -20,7 +24,7 @@ class User < ApplicationRecord
              else
                value || {}
              end
-    super(parsed)
+    super(parsed.to_json)
   end
 
   validates :username, presence: true, uniqueness: true


### PR DESCRIPTION
## Summary
- parse preferences JSON manually since Rails 8 expects `serialize` with one argument
- return `{}` for blank values and store JSON as a string

## Testing
- `bundle exec rake -T | head` *(fails: Could not find gem 'sass-rails (>= 6)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68507c39be08832a8726b62cbf8b2d90