### PR TITLE
Add admin seed user

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,7 @@
-User.create!(username: 'admin', email: 'admin@example.com', password: 'password', password_confirmation: 'password')
+# Create a default admin user if it does not already exist
+User.find_or_create_by!(username: 'admin') do |user|
+  user.email = 'admin@example.com'
+  user.password = 'admin'
+  user.password_confirmation = 'admin'
+end
+


### PR DESCRIPTION
## Summary
- add default admin user in `db/seeds.rb`

## Testing
- `bundle exec rake -T | head` *(fails: Could not find gem 'rails (~> 8.0.0)')*

------
https://chatgpt.com/codex/tasks/task_e_68507e05ad58832a980a1a210869ea2c