### PR TITLE
Fix password length in seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
 # Create a default admin user if it does not already exist
 User.find_or_create_by!(username: 'admin') do |user|
   user.email = 'admin@example.com'
-  user.password = 'admin'
-  user.password_confirmation = 'admin'
+  user.password = 'admin123'
+  user.password_confirmation = 'admin123'
 end
 


### PR DESCRIPTION
## Summary
- fix default admin seed password to satisfy Devise validation

## Testing
- `bash -x scripts/setup.sh` *(fails: building libllama terminated)*
- `bin/rails db:migrate` *(fails: missing gems during bundle setup)*

------
https://chatgpt.com/codex/tasks/task_e_68507ee160e8832a8413c0e89b5af216