### PR TITLE
Add homepage test script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,16 @@ This repository is a Rails 8.0 project.
 
 ## Contributing
 
-1. After making changes, run `bundle exec rake -T | head` to verify Rake tasks
-   load. If the command fails due to missing Ruby versions, mention it in the
-   Testing section.
+1. After making changes, run the test script to install dependencies,
+   migrate, seed the database, and verify the homepage in the Rails test
+   environment. The script starts the server in the background so you can
+   continue working while it checks the app:
+
+   ```bash
+   scripts/test_homepage.sh
+   ```
+
+   If any command fails due to missing dependencies or other issues,
+   mention it in the Testing section.
 2. Commit with clear messages.
 3. Cite modified lines in PR summaries.

--- a/scripts/test_homepage.sh
+++ b/scripts/test_homepage.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Run setup and verify the homepage in test mode
+RAILS_ENV=test
+
+scripts/setup.sh
+
+bin/rails db:migrate RAILS_ENV=$RAILS_ENV
+bin/rails db:setup RAILS_ENV=$RAILS_ENV
+bin/rails db:seed RAILS_ENV=$RAILS_ENV
+
+bin/rails s -e $RAILS_ENV -d
+sleep 5
+curl -I http://localhost:3000
+pkill -f puma


### PR DESCRIPTION
## Summary
- add `scripts/test_homepage.sh`
- guide contributors to use the new test script

## Testing
- `scripts/test_homepage.sh` *(fails: schema creation needed)*
- `bin/rails db:seed RAILS_ENV=test` *(fails: record already exists)*
- `bin/rails s -e test -d && curl -I http://localhost:3000` *(returns 500)*

------
https://chatgpt.com/codex/tasks/task_e_68507d75e720832ab1a3f34f330aac96