### PR TITLE
Allow username login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,5 +8,6 @@ class ApplicationController < ActionController::Base
     extra = [:username, :preferences]
     devise_parameter_sanitizer.permit(:sign_up, keys: extra)
     devise_parameter_sanitizer.permit(:account_update, keys: extra)
+    devise_parameter_sanitizer.permit(:sign_in, keys: [:login])
   end
 end

--- a/app/views/devise/sessions/new.html.rbl
+++ b/app/views/devise/sessions/new.html.rbl
@@ -3,8 +3,8 @@
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
     <div class="space-y-4">
       <div class="space-y-1">
-        <%= f.label :email, class: 'block text-sm font-medium' %>
-        <%= f.email_field :email, autofocus: true, class: 'border rounded w-full p-2' %>
+        <%= f.label :login, 'Username or Email', class: 'block text-sm font-medium' %>
+        <%= f.text_field :login, autofocus: true, class: 'border rounded w-full p-2' %>
       </div>
       <div class="space-y-1">
         <%= f.label :password, class: 'block text-sm font-medium' %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,4 +3,5 @@ Devise.setup do |config|
   config.mailer_sender = 'please-change-me@example.com'
   config.secret_key = 'dummysecretkey'
   config.parent_controller = 'ApplicationController'
+  config.authentication_keys = [:login]
 end


### PR DESCRIPTION
## Summary
- allow login with username or email
- permit :login param in Devise
- adjust login page for username or email field

## Testing
- `bash scripts/setup.sh` *(fails: build libllama)*
- `bin/rails db:migrate` *(fails: missing gem rails)*
- `bin/rails db:setup` *(not run due to previous failure)*
- `bash scripts/test_homepage.sh` *(fails: llama.cpp already exists)*
- `bin/rails s -d && curl -I http://localhost:3000` *(fails: bundle missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_6850812dbc2c832ab16f40088bd7da19