### PR TITLE
Switch local LLM to Ollama gemma3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,4 +22,4 @@ gem 'devise'
 gem 'rblade'
 # Use Tailwind for a modern design
 gem 'tailwindcss-rails'
-gem 'llama_cpp'
+gem 'ollama-ruby'

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ TongXin (\u201cOne Heart\u201d) is a minimal social media application built with
 1. Install Ruby 3.2.2 or newer and Bundler.
 2. Install Rails 8 (e.g., `gem install rails -v 8.0.0`).
 3. Run the setup script to install dependencies and prepare the database.
-   The script now also builds the `llama.cpp` library if needed and performs a
-   quick Rails server check. It still skips production gems (via
-   `bundle config set without 'production'`) so libraries like `pg` aren't
+   The script performs a quick Rails server check and skips production gems
+   (via `bundle config set without 'production'`) so libraries like `pg` aren't
    required during development:
 
    ```bash
@@ -44,9 +43,16 @@ TongXin (\u201cOne Heart\u201d) is a minimal social media application built with
 6. Visit `http://localhost:3000` to see the app.
 7. Enter your interests as JSON in the *Interests* field when creating or
    editing your account (e.g. `{ "keywords": ["rails", "ruby"] }`).
-8. To enable AI recommendations, install a local Llama model using the
-   `llama_cpp` gem and set `LLM_MODEL_PATH` to your model file. If the model
-   can't load, the app falls back to simple keyword matching.
+8. To enable AI recommendations, install [Ollama](https://ollama.com/) and pull
+   the `gemma3:4b` model:
+
+   ```bash
+   ollama pull gemma3:4b
+   ```
+
+   The app connects to `http://localhost:11434` by default. Set `OLLAMA_URL` if
+   your server runs elsewhere. If the model can't load, the app falls back to
+   simple keyword matching.
 
 ## Compliance
 

--- a/app/services/local_llm_client.rb
+++ b/app/services/local_llm_client.rb
@@ -1,14 +1,16 @@
 class LocalLlmClient
-  DEFAULT_MODEL_PATH = ENV.fetch('LLM_MODEL_PATH', 'models/llama.bin')
+  DEFAULT_MODEL = ENV.fetch('OLLAMA_MODEL', 'gemma3:4b')
+  DEFAULT_URL = ENV.fetch('OLLAMA_URL', 'http://localhost:11434')
 
-  def initialize(model_path: DEFAULT_MODEL_PATH)
-    require 'llama_cpp'
-    @context = LlamaCpp::Context.new(model_path: model_path)
+  def initialize(model: DEFAULT_MODEL, url: DEFAULT_URL)
+    require 'ollama'
+    @client = Ollama::Client.new(base_url: url)
+    @model = model
   rescue LoadError
-    raise 'Please add the llama_cpp gem to use the local LLM.'
+    raise 'Please add the ollama-ruby gem to use the local LLM.'
   end
 
   def complete(prompt, tokens: 64)
-    @context.complete(prompt: prompt, n_predict: tokens).to_s
+    @client.generate(model: @model, prompt:, options: { num_predict: tokens }).response.to_s
   end
 end

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,23 +1,9 @@
 #!/bin/bash
 set -e
 
-# Build libllama if the llama_cpp gem's native extension can't
-# find it. This allows the local LLM features to work out of the box.
-if ! ldconfig -p | grep -q libllama; then
-  echo "Building libllama from source"
-  git clone --depth 1 https://github.com/ggerganov/llama.cpp.git /tmp/llama.cpp
-  cmake -S /tmp/llama.cpp -B /tmp/llama.cpp/build -DLLAMA_STATIC=OFF -DLLAMA_CURL=OFF
-  cmake --build /tmp/llama.cpp/build --target llama
-  sudo cp /tmp/llama.cpp/build/bin/libllama.so /usr/local/lib/
-  sudo cp /tmp/llama.cpp/include/llama*.h /usr/local/include/
-  sudo cp /tmp/llama.cpp/ggml/include/*.h /usr/local/include/
-  sudo ldconfig
-fi
-
 # Install Ruby dependencies and set up the database
 echo "Installing gems"
 bundle config set --local without 'production'
-bundle config set --local build.llama_cpp --with-llama-dir=/usr/local
 bundle install
 
 echo "Setting up the database"


### PR DESCRIPTION
## Summary
- replace `llama_cpp` with `ollama-ruby`
- call the Ollama API in `LocalLlmClient`
- simplify setup script
- document using `gemma3:4b` in README

## Testing
- `scripts/test_homepage.sh`
- `scripts/setup.sh`
- `bin/rails db:migrate`
- `bin/rails db:setup`
- `bin/rails s -d && curl -I http://localhost:3000 && pkill -f puma`

------
https://chatgpt.com/codex/tasks/task_e_6850814fff1c832aa9a419838423f9a6