### PR TITLE
Add Turbo-powered like button

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -4,12 +4,30 @@ class LikesController < ApplicationController
 
   def create
     @post.likes.find_or_create_by(user: current_user)
-    redirect_to @post
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace(
+          view_context.dom_id(@post, :likes),
+          partial: 'posts/like_button',
+          locals: { post: @post }
+        )
+      end
+      format.html { redirect_to @post }
+    end
   end
 
   def destroy
     @post.likes.find_by(user: current_user)&.destroy
-    redirect_to @post
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace(
+          view_context.dom_id(@post, :likes),
+          partial: 'posts/like_button',
+          locals: { post: @post }
+        )
+      end
+      format.html { redirect_to @post }
+    end
   end
 
   private

--- a/app/views/posts/_like_button.html.rbl
+++ b/app/views/posts/_like_button.html.rbl
@@ -1,0 +1,14 @@
+<%= turbo_frame_tag dom_id(post, :likes) do %>
+  <span class="mr-2"><%= pluralize(post.likes.count, 'like') %></span>
+  <% if user_signed_in? %>
+    <% if post.likes.exists?(user: current_user) %>
+      <%= button_to 'Unlike', post_like_path(post), method: :delete,
+            form: { data: { turbo_frame: dom_id(post, :likes) } },
+            class: 'text-red-600 hover:underline text-sm' %>
+    <% else %>
+      <%= button_to 'Like', post_like_path(post),
+            form: { data: { turbo_frame: dom_id(post, :likes) } },
+            class: 'text-blue-600 hover:underline text-sm' %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/posts/_post_card.html.rbl
+++ b/app/views/posts/_post_card.html.rbl
@@ -8,15 +8,8 @@
   <% end %>
   <p class="text-gray-700 mb-4"><%= truncate(post.body, length: 100) %></p>
   <div class="flex justify-between items-center">
-    <span class="text-sm"><%= pluralize(post.likes.count, 'like') %></span>
+    <%= render partial: 'posts/like_button', locals: { post: post } %>
     <div class="space-x-2">
-      <% if user_signed_in? %>
-        <% if post.likes.exists?(user: current_user) %>
-          <%= button_to 'Unlike', post_like_path(post), method: :delete, class: 'text-red-600 hover:underline text-sm' %>
-        <% else %>
-          <%= button_to 'Like', post_like_path(post), class: 'text-blue-600 hover:underline text-sm' %>
-        <% end %>
-      <% end %>
       <% if current_user == post.user %>
         <%= link_to 'Edit', edit_post_path(post), class: 'text-sm text-blue-600 hover:underline' %>
       <% end %>

--- a/app/views/posts/show.html.rbl
+++ b/app/views/posts/show.html.rbl
@@ -12,14 +12,7 @@
     <%= link_to 'Back', posts_path, class: 'text-blue-600 hover:underline' %>
   </div>
   <div class="mb-2">
-    <span class="mr-2"><%= pluralize(@post.likes.count, 'like') %></span>
-    <% if user_signed_in? %>
-      <% if @post.likes.exists?(user: current_user) %>
-        <%= button_to 'Unlike', post_like_path(@post), method: :delete, class: 'text-red-600 hover:underline' %>
-      <% else %>
-        <%= button_to 'Like', post_like_path(@post), class: 'text-blue-600 hover:underline' %>
-      <% end %>
-    <% end %>
+    <%= render partial: 'posts/like_button', locals: { post: @post } %>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- render like/unlike buttons in a new turbo-frame partial
- respond to like/unlike with Turbo Stream updates
- embed new partial in post views

## Testing
- `scripts/test_homepage.sh`
- `scripts/setup.sh`
- `bin/rails db:migrate`
- `bin/rails db:setup`
- `bin/rails s -d`
- `curl -I http://localhost:3000`
- `pkill -f puma`


------
https://chatgpt.com/codex/tasks/task_e_68508ac2c604832ab4ed479f37bd78bc