### PR TITLE
Improve user profiles

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    extra = [:username, :preferences]
+    extra = [:username, :preferences, :avatar_url, :bio]
     devise_parameter_sanitizer.permit(:sign_up, keys: extra)
     devise_parameter_sanitizer.permit(:account_update, keys: extra)
     devise_parameter_sanitizer.permit(:sign_in, keys: [:login])

--- a/app/views/devise/registrations/edit.html.rbl
+++ b/app/views/devise/registrations/edit.html.rbl
@@ -10,6 +10,14 @@
     <%= f.text_area :preferences, rows: 3, class: 'border rounded w-full p-2' %>
   </div>
   <div class="space-y-1">
+    <%= f.label :avatar_url, class: 'block text-sm font-medium' %>
+    <%= f.text_field :avatar_url, class: 'border rounded w-full p-2' %>
+  </div>
+  <div class="space-y-1">
+    <%= f.label :bio, class: 'block text-sm font-medium' %>
+    <%= f.text_area :bio, rows: 3, class: 'border rounded w-full p-2' %>
+  </div>
+  <div class="space-y-1">
     <%= f.label :email, class: 'block text-sm font-medium' %>
     <%= f.email_field :email, class: 'border rounded w-full p-2' %>
   </div>

--- a/app/views/devise/registrations/new.html.rbl
+++ b/app/views/devise/registrations/new.html.rbl
@@ -11,6 +11,14 @@
         <%= f.text_area :preferences, rows: 3, class: 'border rounded w-full p-2' %>
       </div>
       <div class="space-y-1">
+        <%= f.label :avatar_url, class: 'block text-sm font-medium' %>
+        <%= f.text_field :avatar_url, class: 'border rounded w-full p-2' %>
+      </div>
+      <div class="space-y-1">
+        <%= f.label :bio, class: 'block text-sm font-medium' %>
+        <%= f.text_area :bio, rows: 3, class: 'border rounded w-full p-2' %>
+      </div>
+      <div class="space-y-1">
         <%= f.label :email, class: 'block text-sm font-medium' %>
         <%= f.email_field :email, class: 'border rounded w-full p-2' %>
       </div>

--- a/app/views/users/show.html.rbl
+++ b/app/views/users/show.html.rbl
@@ -3,7 +3,11 @@
   <% if @user.avatar_url.present? %>
     <img src="<%= @user.avatar_url %>" alt="avatar" class="mb-4 w-32 h-32 rounded-full object-cover">
   <% end %>
+  <% if @user.bio.present? %>
+    <p class="mb-2 whitespace-pre-wrap"><%= @user.bio %></p>
+  <% end %>
   <p class="mb-2">Email: <%= @user.email %></p>
+  <p class="mb-2">Followers: <%= @user.followers.count %> | Following: <%= @user.following.count %></p>
   <% if current_user == @user %>
     <%= link_to 'Edit', edit_user_registration_path, class: 'text-blue-600 hover:underline mr-2' %>
     <%= link_to 'Delete', registration_path(:user), method: :delete, data: { confirm: 'Are you sure?' }, class: 'text-red-600 hover:underline mr-2' %>
@@ -16,3 +20,14 @@
     <% end %>
   <% end %>
 </div>
+
+<h2 class="text-2xl font-bold mt-6 mb-4">Posts</h2>
+<% if @user.posts.any? %>
+  <div class="grid gap-4 md:grid-cols-2">
+    <% @user.posts.order(created_at: :desc).each do |post| %>
+      <%= render 'posts/post_card', post: post %>
+    <% end %>
+  </div>
+<% else %>
+  <p class="text-gray-600">No posts yet.</p>
+<% end %>

--- a/db/migrate/20250616221415_add_bio_to_users.rb
+++ b/db/migrate/20250616221415_add_bio_to_users.rb
@@ -1,0 +1,5 @@
+class AddBioToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :bio, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_16_215639) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_16_221415) do
   create_table "comments", force: :cascade do |t|
     t.text "body", null: false
     t.integer "user_id", null: false
@@ -80,6 +80,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_16_215639) do
     t.datetime "remember_created_at"
     t.text "preferences"
     t.string "avatar_url"
+    t.text "bio"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## Summary
- permit avatar and bio fields in `ApplicationController`
- let users set avatar URL and bio during sign up and edit
- show follower counts and user bio in the profile
- list all posts on the user's profile page
- add migration to store a bio for each user

## Testing
- `scripts/test_homepage.sh`
- `bin/rails db:setup`
- `bin/rails s -d`
- `curl -I http://localhost:3000`
- `pkill -f puma`


------
https://chatgpt.com/codex/tasks/task_e_685096555b98832a91b86b3a784c6b6d