### PR TITLE
Add simple SPA shell

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,5 @@
 class PostsController < ApplicationController
+  respond_to :html, :json
   skip_before_action :authenticate_user!, only: [:index, :show, :trending, :tagged]
   before_action :set_post, only: [:show, :edit, :update, :destroy]
 
@@ -17,6 +18,10 @@ class PostsController < ApplicationController
       @recommended_posts = recent_posts.select { |post| recommender.interested?(post) }
     end
     @top_tags = Tag.trending.limit(10)
+    respond_to do |format|
+      format.html
+      format.json { render json: @posts }
+    end
   end
 
   def tagged
@@ -40,6 +45,10 @@ class PostsController < ApplicationController
   end
 
   def show
+    respond_to do |format|
+      format.html
+      format.json { render json: @post }
+    end
   end
 
   def new

--- a/app/controllers/spa_controller.rb
+++ b/app/controllers/spa_controller.rb
@@ -1,0 +1,6 @@
+class SpaController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  def index
+  end
+end

--- a/app/views/spa/index.html.rbl
+++ b/app/views/spa/index.html.rbl
@@ -1,0 +1,17 @@
+<h1 class="text-3xl font-bold mb-6 text-center">SPA Posts</h1>
+<div id="spa-posts" class="space-y-4"></div>
+<script>
+  document.addEventListener('turbo:load', () => {
+    fetch('/posts.json')
+      .then(resp => resp.json())
+      .then(posts => {
+        const container = document.getElementById('spa-posts');
+        container.innerHTML = posts.map(post => `
+          <div class="border p-4 rounded bg-white">
+            <h2 class="text-xl font-semibold">${post.title}</h2>
+            <p class="mt-2 text-gray-700">${post.body}</p>
+          </div>
+        `).join('');
+      });
+  });
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  root 'posts#index'
+  root 'spa#index'
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   resources :posts do
     resources :comments, only: [:create, :destroy]


### PR DESCRIPTION
## Summary
- set `/` to render a new SPA controller
- serve posts JSON for dynamic loading
- add a basic SPA view with JS fetch

## Testing
- `scripts/test_homepage.sh`
- `scripts/setup.sh` *(fails: FOREIGN KEY constraint failed)*
- `bin/rails db:migrate`
- `bin/rails db:setup` *(fails: FOREIGN KEY constraint failed)*
- `bin/rails s -d`
- `curl -I http://localhost:3000`
- `pkill -f puma`


------
https://chatgpt.com/codex/tasks/task_e_6851dd3f1bf0832a9e8eab53f35340ee