### PR TITLE
Add start_desktop script

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ the same as the web version. Use the provided script to build the desktop app:
 scripts/package_desktop.sh
 ```
 
+Launch the compiled version with:
+
+```bash
+scripts/start_desktop.sh
+```
+
 ## Compliance
 
 This project strives to follow applicable regulations and moderation requirements. Content posted by users should comply with local laws and community standards.

--- a/scripts/start_desktop.sh
+++ b/scripts/start_desktop.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Launch the packaged Electron desktop app
+APP_ROOT="$(dirname "$0")/../desktop"
+APP_NAME="tongxin-desktop"
+
+ARCH="$(uname -m)"
+PLATFORM="$(uname | tr '[:upper:]' '[:lower:]')"
+DIR="${APP_ROOT}/${APP_NAME}-${PLATFORM}-${ARCH}"
+
+if [ "$PLATFORM" = "darwin" ]; then
+  EXEC="${DIR}/${APP_NAME}.app/Contents/MacOS/${APP_NAME}"
+else
+  EXEC="${DIR}/${APP_NAME}"
+fi
+
+if [ ! -f "$EXEC" ]; then
+  echo "Compiled app not found: $EXEC"
+  echo "Run scripts/package_desktop.sh first"
+  exit 1
+fi
+
+"$EXEC"


### PR DESCRIPTION
## Summary
- add script to launch the packaged Electron app
- document how to start the desktop build

## Testing
- `scripts/test_homepage.sh`
- `scripts/setup.sh` *(fails: ActiveRecord::InvalidForeignKey)*
- `bin/rails db:migrate`
- `bin/rails db:setup` *(fails: ActiveRecord::InvalidForeignKey)*
- `bin/rails s -d`
- `curl -I http://localhost:3000`
- `pkill -f puma`


------
https://chatgpt.com/codex/tasks/task_e_6851dd19260c832aac7f50998bf0441e