### PR TITLE
Fix SPA route handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ TongXin (\u201cOne Heart\u201d) is a minimal social media application built with
 - Modern UI styled with Tailwind CSS
 - Backend now operates API-only, views are handled client-side
 - React single page app handles all UI via React Router, while Rails only serves JSON
-- Views rendered with rblade templates
+- Rails routes include a catch-all so direct links load the SPA correctly
+- SPA uses React Router BrowserRouter for clean URLs
+- Single rblade template loads the React SPA for all pages
 - Integrated e-commerce with product links, shopping cart, and direct purchasing
 - Advanced content creation tools with image/video editing and AR filters
 - Live streaming interface with optional shopping links

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,21 +24,22 @@ class PostsController < ApplicationController
   def tagged
     @tag = Tag.find_by!(name: params[:name])
     @posts = @tag.posts.order(created_at: :desc)
-    render :index
+    render json: @posts
   end
 
   def feed
     @posts = Post.where(user_id: current_user.following_ids).order(created_at: :desc)
-    render :index
+    render json: @posts
   end
 
   def trending
     @posts = Post.trending.limit(10)
-    render :trending
+    render json: @posts
   end
 
   def videos
     @posts = Post.where.not(video_url: [nil, '']).order(created_at: :desc)
+    render json: @posts
   end
 
   def show
@@ -47,6 +48,7 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
+    render json: @post
   end
 
   def create
@@ -60,6 +62,7 @@ class PostsController < ApplicationController
   end
 
   def edit
+    render json: @post
   end
 
   def update

--- a/app/views/spa/index.html.rbl
+++ b/app/views/spa/index.html.rbl
@@ -1,17 +1,42 @@
-<h1 class="text-3xl font-bold mb-6 text-center">SPA Posts</h1>
+<h1 class="text-3xl font-bold mb-6 text-center">TongXin SPA</h1>
+<nav class="mb-4 space-x-4 text-center">
+  <a href="/" data-turbo="false" class="text-blue-600 hover:underline">Home</a>
+  <a href="/trending" data-turbo="false" class="text-blue-600 hover:underline">Trending</a>
+</nav>
 <div id="spa" class="space-y-4"></div>
 <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
 <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
 <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.production.min.js" crossorigin></script>
 <script>
   const e = React.createElement;
-  const { HashRouter, Routes, Route, Link, useParams } = ReactRouterDOM;
+  const { BrowserRouter, Routes, Route, Link, useParams } = ReactRouterDOM;
 
   function PostList() {
     const [posts, setPosts] = React.useState([]);
 
     React.useEffect(() => {
       fetch('/posts.json')
+        .then(resp => resp.json())
+        .then(data => setPosts(data));
+    }, []);
+
+    return e(React.Fragment, null,
+      posts.map(post =>
+        e('div', { className: 'border p-4 rounded bg-white', key: post.id },
+          e(Link, { to: `/posts/${post.id}` },
+            e('h2', { className: 'text-xl font-semibold' }, post.title)
+          ),
+          e('p', { className: 'mt-2 text-gray-700' }, post.body)
+        )
+      )
+    );
+  }
+
+  function TrendingList() {
+    const [posts, setPosts] = React.useState([]);
+
+    React.useEffect(() => {
+      fetch('/trending.json')
         .then(resp => resp.json())
         .then(data => setPosts(data));
     }, []);
@@ -48,9 +73,10 @@
   }
 
   function App() {
-    return e(HashRouter, null,
+    return e(BrowserRouter, null,
       e(Routes, null,
         e(Route, { path: '/', element: e(PostList) }),
+        e(Route, { path: '/trending', element: e(TrendingList) }),
         e(Route, { path: '/posts/:id', element: e(PostDetail) })
       )
     );

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,26 @@
 Rails.application.routes.draw do
   root 'spa#index'
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+
+  # All HTML post pages are served by the SPA
+  get 'posts(/*path)', to: 'spa#index', constraints: ->(req) { req.format.html? }
+
   resources :posts, defaults: { format: :json } do
     resources :comments, only: [:create, :destroy]
     resource :like, only: [:create, :destroy]
   end
-  get 'feed', to: 'posts#feed'
-  get 'trending', to: 'posts#trending'
-  get 'videos', to: 'posts#videos'
-  get 'notifications', to: 'notifications#index'
-  get 'tags/:name', to: 'posts#tagged', as: :tag
-  resources :users, only: [:show] do
+  get 'feed', to: 'spa#index', constraints: ->(req) { req.format.html? }
+  get 'feed', to: 'posts#feed', defaults: { format: :json }
+  get 'trending', to: 'spa#index', constraints: ->(req) { req.format.html? }
+  get 'trending', to: 'posts#trending', defaults: { format: :json }
+  get 'videos', to: 'spa#index', constraints: ->(req) { req.format.html? }
+  get 'videos', to: 'posts#videos', defaults: { format: :json }
+  get 'notifications', to: 'spa#index', constraints: ->(req) { req.format.html? }
+  get 'notifications', to: 'notifications#index', defaults: { format: :json }
+  get 'tags/:name', to: 'spa#index', constraints: ->(req) { req.format.html? }
+  get 'tags/:name', to: 'posts#tagged', as: :tag, defaults: { format: :json }
+  get 'users/:id', to: 'spa#index', constraints: ->(req) { req.format.html? }
+  resources :users, only: [:show], defaults: { format: :json } do
     member do
       post :follow
       delete :unfollow
@@ -26,4 +36,7 @@ Rails.application.routes.draw do
   resources :live_streams, only: [:index, :show, :create]
   resources :brands, only: [:index]
   resources :partnerships, only: [:create]
+
+  # Catch-all for React Router paths so direct visits work
+  get '*path', to: 'spa#index', constraints: ->(req) { !req.xhr? && req.format.html? }
 end


### PR DESCRIPTION
## Summary
- expand SPA with a nav bar and trending route
- switch all posts-related actions to render JSON
- serve the SPA for all HTML requests in routes
- note SPA template usage in the README

## Testing
- `scripts/test_homepage.sh`
- `scripts/setup.sh` *(fails: ActiveRecord::InvalidForeignKey)*
- `bin/rails db:migrate --trace`
- `bin/rails db:setup --trace` *(fails: ActiveRecord::InvalidForeignKey)*
- `bin/rails s -d && curl -I http://localhost:3000 && pkill -f puma`


------
https://chatgpt.com/codex/tasks/task_e_6851eefd45fc832aa8c6713e7b8992e1