### PR TITLE
Fix asset loading in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,4 +2,10 @@
 
 Rails.application.configure do
   config.eager_load = true
+  # Disable asset fingerprinting so static HTML can reference
+  # non-digested filenames like /assets/application.js in production.
+  config.assets.digest = false
+
+  # Allow on-the-fly compilation if precompiled assets are missing.
+  config.assets.compile = true
 end


### PR DESCRIPTION
## Summary
- disable asset digests and compile on the fly in production

## Testing
- `scripts/test_homepage.sh`


------
https://chatgpt.com/codex/tasks/task_e_68520b470834832aacc0769bdab593da