### PR TITLE
Fix React Router load error

### DIFF
--- a/app/views/spa/index.html.erb
+++ b/app/views/spa/index.html.erb
@@ -15,7 +15,7 @@
     <div id="spa" class="space-y-4"></div>
     <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-    <%= javascript_include_tag "react-router-dom" %>
+    <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.production.min.js" crossorigin></script>
     <%= javascript_include_tag "posts" %>
     <%= javascript_include_tag "trending" %>
     <%= javascript_include_tag "videos" %>

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <div id="spa" class="space-y-4"></div>
     <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-    <script src="/assets/react-router-dom.js"></script>
+    <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.production.min.js" crossorigin></script>
     <script src="/assets/posts.js"></script>
     <script src="/assets/trending.js"></script>
     <script src="/assets/videos.js"></script>


### PR DESCRIPTION
## Summary
- load React Router DOM directly from CDN for SPA

## Testing
- `scripts/setup.sh` *(fails: ActiveRecord::InvalidForeignKey)*
- `bin/rails db:migrate`
- `bin/rails s -d`
- `curl -I http://localhost:3000`
- `pkill -f puma`
- `scripts/test_homepage.sh` *(fails: ActiveRecord::InvalidForeignKey)*

------
https://chatgpt.com/codex/tasks/task_e_68520d209800832a823cf27a8a29d643