### PR TITLE
Fix asset pipeline errors and use local React Router

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
 //= link_directory ../javascripts .js
-//= link_directory ../../vendor/assets/javascripts .js
+//= link_directory ../../../vendor/assets/javascripts .js

--- a/app/views/spa/index.html.erb
+++ b/app/views/spa/index.html.erb
@@ -15,7 +15,7 @@
     <div id="spa" class="space-y-4"></div>
     <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-    <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.production.min.js" crossorigin></script>
+    <%= javascript_include_tag "react-router-dom" %>
     <%= javascript_include_tag "posts" %>
     <%= javascript_include_tag "trending" %>
     <%= javascript_include_tag "videos" %>

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <div id="spa" class="space-y-4"></div>
     <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-    <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.production.min.js" crossorigin></script>
+    <script src="/assets/react-router-dom.js"></script>
     <script src="/assets/posts.js"></script>
     <script src="/assets/trending.js"></script>
     <script src="/assets/videos.js"></script>


### PR DESCRIPTION
## Summary
- correct vendor asset path in manifest
- reference React Router DOM locally

## Testing
- `scripts/test_homepage.sh`
- `scripts/setup.sh` *(fails: ActiveRecord::InvalidForeignKey)*
- `bin/rails db:migrate`
- `bin/rails s -d`
- `curl -I http://localhost:3000`
- `pkill -f puma`


------
https://chatgpt.com/codex/tasks/task_e_6852d42cf5e4832a9e005071ed9920b8