### PR TITLE
Fix asset loading in dev/test

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,4 +2,6 @@
 
 Rails.application.configure do
   config.eager_load = false
+  # Allow assets like application.js to be served without precompiling
+  config.assets.compile = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -2,4 +2,6 @@
 
 Rails.application.configure do
   config.eager_load = false
+  # Allow asset pipeline to compile missing files during tests
+  config.assets.compile = true
 end


### PR DESCRIPTION
## Summary
- serve assets dynamically in development
- allow asset compilation in test

## Testing
- `scripts/setup.sh` *(fails: Don't run Bundler as root. Installing your bundle as root will break this application for all non-root users on this machine.)*
- `scripts/test_homepage.sh` *(fails: Installing gems...)*
- `bin/rails db:migrate` *(fails: Could not find sass-rails-6.0.0, sassc-rails-2.1.2, sassc-2.4.0 in locally installed gems)*
- `bin/rails s -d && curl -I http://localhost:3000` *(fails: Could not find sass-rails-6.0.0, sassc-rails-2.1.2, sassc-2.4.0 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_6852e005d388832a97ca799f43792933