### PR TITLE
Fix React Router CDN path

### DIFF
--- a/app/views/spa/index.html.erb
+++ b/app/views/spa/index.html.erb
@@ -15,7 +15,7 @@
     <div id="spa" class="space-y-4"></div>
     <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-    <%= javascript_include_tag "react-router-dom" %>
+    <script src="https://unpkg.com/react-router-dom@6/dist/umd/react-router-dom.production.min.js" crossorigin></script>
     <%= javascript_include_tag "posts" %>
     <%= javascript_include_tag "trending" %>
     <%= javascript_include_tag "videos" %>

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <div id="spa" class="space-y-4"></div>
     <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-    <script src="/assets/react-router-dom.js"></script>
+    <script src="https://unpkg.com/react-router-dom@6/dist/umd/react-router-dom.production.min.js" crossorigin></script>
     <script src="/assets/posts.js"></script>
     <script src="/assets/trending.js"></script>
     <script src="/assets/videos.js"></script>


### PR DESCRIPTION
## Summary
- correct `react-router-dom` CDN URL in SPA and public templates

## Testing
- `scripts/test_homepage.sh`
- `scripts/setup.sh`
- `bin/rails db:migrate`
- `bin/rails s -d`
- `curl -I http://localhost:3000`
- `pkill -f puma`


------
https://chatgpt.com/codex/tasks/task_e_6852e34855c0832aac76a7e9bc9540e3