### PR TITLE
Fix React Router not loading from CDN

### DIFF
--- a/app/views/spa/index.html.erb
+++ b/app/views/spa/index.html.erb
@@ -15,7 +15,7 @@
     <div id="spa" class="space-y-4"></div>
     <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
-    <script src="https://unpkg.com/react-router-dom@6/dist/umd/react-router-dom.production.min.js" crossorigin></script>
+    <%= javascript_include_tag "react-router-dom" %>
     <%= javascript_include_tag "posts" %>
     <%= javascript_include_tag "trending" %>
     <%= javascript_include_tag "videos" %>


### PR DESCRIPTION
## Summary
- load `react-router-dom` from local asset pipeline

## Testing
- `scripts/test_homepage.sh`
- `scripts/setup.sh`
- `bin/rails s -d`
- `curl -I http://localhost:3000`
- `pkill -f puma`


------
https://chatgpt.com/codex/tasks/task_e_6852ee27d7e0832aace23670518c2642