### PR TITLE
Add script for easy dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ cd nextjs
 npm install
 npm run dev
 ```
+3. Alternatively run the helper script from the project root:
+
+```bash
+./run.sh
+```
 
 Visit `http://localhost:3000` to use the app. The homepage shows your feed and recommendations. Additional pages:
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Install dependencies and run the dev server
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR/nextjs"
+
+if ! command -v npm > /dev/null; then
+  echo "npm not found. Please install Node.js 18 or newer." >&2
+  exit 1
+fi
+
+npm install
+npm run dev
+


### PR DESCRIPTION
## Summary
- add `run.sh` to automate installing dependencies and running the dev server
- document the helper script in the Setup section

## Testing
- `npm install` in `nextjs`
- `NEXT_TELEMETRY_DISABLED=1 npm run dev` and `curl -I http://localhost:3000`

------
https://chatgpt.com/codex/tasks/task_e_68531425c328832ab60d4658f4b45026