### PR TITLE
Fix iron-session imports for v8

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -3,3 +3,12 @@ export const sessionOptions = {
   cookieName: 'tongxin_session',
   cookieOptions: { secure: process.env.NODE_ENV === 'production' }
 }
+
+import { getIronSession } from 'iron-session'
+
+export function withSessionRoute(handler) {
+  return async (req, res) => {
+    req.session = await getIronSession(req, res, sessionOptions)
+    return handler(req, res)
+  }
+}

--- a/pages/api/comments.js
+++ b/pages/api/comments.js
@@ -1,5 +1,4 @@
-import { withIronSessionApiRoute } from 'iron-session/next'
-import { sessionOptions } from '../../lib/session'
+import { withSessionRoute } from '../../lib/session'
 import db from '../../models'
 
 async function handler(req, res) {
@@ -21,4 +20,4 @@ async function handler(req, res) {
   res.status(405).end()
 }
 
-export default withIronSessionApiRoute(handler, sessionOptions)
+export default withSessionRoute(handler)

--- a/pages/api/follows.js
+++ b/pages/api/follows.js
@@ -1,5 +1,4 @@
-import { withIronSessionApiRoute } from 'iron-session/next'
-import { sessionOptions } from '../../lib/session'
+import { withSessionRoute } from '../../lib/session'
 import db from '../../models'
 
 async function handler(req, res) {
@@ -32,4 +31,4 @@ async function handler(req, res) {
   res.status(405).end()
 }
 
-export default withIronSessionApiRoute(handler, sessionOptions)
+export default withSessionRoute(handler)

--- a/pages/api/likes.js
+++ b/pages/api/likes.js
@@ -1,5 +1,4 @@
-import { withIronSessionApiRoute } from 'iron-session/next'
-import { sessionOptions } from '../../lib/session'
+import { withSessionRoute } from '../../lib/session'
 import db from '../../models'
 
 async function handler(req, res) {
@@ -13,4 +12,4 @@ async function handler(req, res) {
   res.status(200).json(post)
 }
 
-export default withIronSessionApiRoute(handler, sessionOptions)
+export default withSessionRoute(handler)

--- a/pages/api/posts.js
+++ b/pages/api/posts.js
@@ -1,5 +1,4 @@
-import { withIronSessionApiRoute } from 'iron-session/next'
-import { sessionOptions } from '../../lib/session'
+import { withSessionRoute } from '../../lib/session'
 import db from '../../models'
 
 async function handler(req, res) {
@@ -69,4 +68,4 @@ async function handler(req, res) {
   res.status(405).end()
 }
 
-export default withIronSessionApiRoute(handler, sessionOptions)
+export default withSessionRoute(handler)

--- a/pages/api/recommendations.js
+++ b/pages/api/recommendations.js
@@ -1,5 +1,4 @@
-import { withIronSessionApiRoute } from 'iron-session/next'
-import { sessionOptions } from '../../lib/session'
+import { withSessionRoute } from '../../lib/session'
 import db from '../../models'
 
 async function handler(req, res) {
@@ -9,4 +8,4 @@ async function handler(req, res) {
   res.status(200).json(result)
 }
 
-export default withIronSessionApiRoute(handler, sessionOptions)
+export default withSessionRoute(handler)

--- a/pages/api/session.js
+++ b/pages/api/session.js
@@ -1,5 +1,4 @@
-import { withIronSessionApiRoute } from 'iron-session/next'
-import { sessionOptions } from '../../lib/session'
+import { withSessionRoute, sessionOptions } from '../../lib/session'
 import bcrypt from 'bcryptjs'
 import db from '../../models'
 
@@ -24,4 +23,4 @@ async function handler(req, res) {
   }
 }
 
-export default withIronSessionApiRoute(handler, sessionOptions)
+export default withSessionRoute(handler)


### PR DESCRIPTION
## Summary
- add wrapper that uses `getIronSession`
- update API routes to use new wrapper

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_68531be41e38832abb362cecf60fe392