### PR TITLE
Add default admin seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ npm run dev
 ```
 This script runs Sequelize migrations and seeds to create the local `data/test.db` SQLite database.
 
+The seed data includes a demo administrator account:
+
+- **Username:** `admin`
+- **Password:** `admin123`
+
+This user comes with a couple of example posts so you have some content in the feed right away.
+
 Visit `http://localhost:3000` to use the app. The homepage shows your feed and recommendations. Additional pages:
 
 - `/feed` - your personalized feed

--- a/models/index.js
+++ b/models/index.js
@@ -1,20 +1,15 @@
 'use strict'
-const fs = require('fs')
-const path = require('path')
 const Sequelize = require('sequelize')
-const basename = path.basename(__filename)
 const env = process.env.NODE_ENV || 'development'
 const config = require('../config/config.js')[env]
 
 const db = {}
 const sequelize = new Sequelize(config)
 
-fs.readdirSync(__dirname)
-  .filter(file => file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js')
-  .forEach(file => {
-    const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes)
-    db[model.name] = model
-  })
+db.User = require('./user')(sequelize, Sequelize.DataTypes)
+db.Post = require('./post')(sequelize, Sequelize.DataTypes)
+db.Comment = require('./comment')(sequelize, Sequelize.DataTypes)
+db.Follow = require('./follow')(sequelize, Sequelize.DataTypes)
 
 Object.keys(db).forEach(name => {
   if (db[name].associate) db[name].associate(db)

--- a/seeders/0002-admin.js
+++ b/seeders/0002-admin.js
@@ -1,0 +1,22 @@
+'use strict'
+const bcrypt = require('bcryptjs')
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const password = await bcrypt.hash('admin123', 10)
+    const now = new Date()
+    await queryInterface.bulkInsert('Users', [
+      { username: 'admin', password, createdAt: now, updatedAt: now }
+    ])
+    const [user] = await queryInterface.sequelize.query("SELECT id FROM Users WHERE username='admin' LIMIT 1")
+    const userId = user[0].id
+    await queryInterface.bulkInsert('Posts', [
+      { userId, content: 'Welcome to TongXin', createdAt: now, updatedAt: now },
+      { userId, content: 'Second post from admin', createdAt: now, updatedAt: now }
+    ])
+  },
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('Posts', null, {})
+    await queryInterface.bulkDelete('Users', { username: 'admin' }, {})
+  }
+}


### PR DESCRIPTION
## Summary
- seed an `admin` user with example posts
- document the seeded admin account in the README
- avoid dynamic `require` in Sequelize models

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_68533fda724c832aa74ac1e53697962f