### PR TITLE
Fix seeder Validation error

### DIFF
--- a/seeders/0001-demo.js
+++ b/seeders/0001-demo.js
@@ -15,7 +15,8 @@ module.exports = {
           createdAt: now,
           updatedAt: now
         }
-      ]
+      ],
+      { ignoreDuplicates: true }
     )
     const [user] = await queryInterface.sequelize.query("SELECT id FROM Users WHERE username='test' LIMIT 1")
     const userId = user[0].id

--- a/seeders/0002-admin.js
+++ b/seeders/0002-admin.js
@@ -5,9 +5,11 @@ module.exports = {
   async up(queryInterface, Sequelize) {
     const password = await bcrypt.hash('admin123', 10)
     const now = new Date()
-    await queryInterface.bulkInsert('Users', [
-      { username: 'admin', password, createdAt: now, updatedAt: now }
-    ])
+    await queryInterface.bulkInsert(
+      'Users',
+      [{ username: 'admin', password, createdAt: now, updatedAt: now }],
+      { ignoreDuplicates: true }
+    )
     const [user] = await queryInterface.sequelize.query("SELECT id FROM Users WHERE username='admin' LIMIT 1")
     const userId = user[0].id
     await queryInterface.bulkInsert('Posts', [


### PR DESCRIPTION
## Summary
- make user insertions ignore duplicates so `db:seed:all` can run multiple times without errors

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`
- `npx sequelize-cli db:migrate`
- `npx sequelize-cli db:seed:all`


------
https://chatgpt.com/codex/tasks/task_e_68535661b62c832abc4f4a2c7ba18a2d