### PR TITLE
Improve layout and rename feed page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ TongXin ("One Heart") now runs on [Next.js](https://nextjs.org/) with API routes
 
 - User registration and login with hashed passwords
 - Create, edit and delete posts with optional images and videos
+- Embed YouTube or Bilibili videos directly in posts
 - Comment on posts
 - Like posts and view a trending page
 - Follow other users and view profiles
-- Search posts and see simple AI recommendations
+- Search posts and see simple recommendations
+- Upload a profile avatar and view avatars on posts
 - Modern UI styled with Tailwind CSS
 - Homepage mixes your feed and recommendations
 
@@ -38,7 +40,7 @@ This user comes with a couple of example posts so you have some content in the f
 
 Visit `http://localhost:3000` to use the app. The homepage shows your feed and recommendations. Additional pages:
 
-- `/feed` - your personalized feed
+- `/home` - your personalized feed
 - `/trending` - trending posts
 - `/search` - search posts
 - `/posts/[id]` - view a single post with comments

--- a/components/Avatar.js
+++ b/components/Avatar.js
@@ -1,0 +1,10 @@
+export default function Avatar({ url, size = 32 }) {
+  return (
+    <img
+      src={url || '/avatar-default.svg'}
+      alt="avatar"
+      className="rounded-full object-cover"
+      style={{ width: size, height: size }}
+    />
+  )
+}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -19,7 +19,7 @@ export default function Layout({ children }) {
         <div className="max-w-4xl mx-auto flex items-center justify-between p-4">
           <Link href="/" className="text-xl font-bold">TongXin</Link>
           <nav className="space-x-4 flex items-center">
-            <Link href="/feed">Feed</Link>
+            <Link href="/home">Home</Link>
             <Link href="/trending">Trending</Link>
             <Link href="/search">Search</Link>
             {user ? (

--- a/components/VideoEmbed.js
+++ b/components/VideoEmbed.js
@@ -1,0 +1,27 @@
+export default function VideoEmbed({ url }) {
+  if (!url) return null
+  const yt = url.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/))([^?&]+)/)
+  if (yt) {
+    return (
+      <iframe
+        src={`https://www.youtube.com/embed/${yt[1]}`}
+        className="w-full mb-2"
+        height="315"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+    )
+  }
+  const bv = url.match(/bilibili\.com\/video\/([a-zA-Z0-9]+)/)
+  if (bv) {
+    return (
+      <iframe
+        src={`https://player.bilibili.com/player.html?bvid=${bv[1]}`}
+        className="w-full mb-2"
+        height="360"
+        allowFullScreen
+      />
+    )
+  }
+  return <video src={url} controls className="w-full mb-2" />
+}

--- a/pages/api/users.js
+++ b/pages/api/users.js
@@ -24,13 +24,14 @@ export default async function handler(req, res) {
         .json({
           id: user.id,
           username: user.username,
+          avatarUrl: user.avatarUrl,
           following: follows.map(f => f.followId)
         })
     }
     const users = await User.findAll()
     return res
       .status(200)
-      .json(users.map(u => ({ id: u.id, username: u.username })))
+      .json(users.map(u => ({ id: u.id, username: u.username, avatarUrl: u.avatarUrl })))
   }
 
   res.status(405).end()

--- a/pages/home.js
+++ b/pages/home.js
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
+import Avatar from '../components/Avatar'
+import VideoEmbed from '../components/VideoEmbed'
 
-export default function Feed() {
+export default function HomePage() {
   const [posts, setPosts] = useState([])
   const [usersMap, setUsersMap] = useState({})
 
@@ -9,7 +11,7 @@ export default function Feed() {
     fetch('/api/posts?feed=1').then(r => r.json()).then(setPosts)
     fetch('/api/users').then(r => r.json()).then(list => {
       const m = {}
-      list.forEach(u => (m[u.id] = u.username))
+      list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl }))
       setUsersMap(m)
     })
   }, [])
@@ -28,14 +30,16 @@ export default function Feed() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Your Feed</h1>
-      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+      <h1 className="text-2xl font-bold mb-4">Home</h1>
+      <div className="space-y-4">
         {posts.map(p => (
           <div key={p.id} className="bg-white p-3 rounded-lg shadow">
             <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
-            <div className="text-sm text-gray-500 mb-2">
-              by <Link href={`/users/${p.userId}`}>{usersMap[p.userId] || 'User'}</Link>
+            <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
+              <Avatar url={usersMap[p.userId]?.avatarUrl} size={24} />
+              <Link href={`/users/${p.userId}`}>{usersMap[p.userId]?.username || 'User'}</Link>
             </div>
+            <VideoEmbed url={p.videoUrl} />
             <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
               Like ({p.likes || 0})
             </button>

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -1,6 +1,8 @@
 import { useRouter } from 'next/router'
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
+import Avatar from '../../components/Avatar'
+import VideoEmbed from '../../components/VideoEmbed'
 
 export default function PostPage() {
   const router = useRouter()
@@ -9,12 +11,18 @@ export default function PostPage() {
   const [comments, setComments] = useState([])
   const [commentText, setCommentText] = useState('')
   const [user, setUser] = useState(null)
+  const [usersMap, setUsersMap] = useState({})
 
   useEffect(() => {
     if (!id) return
     fetch('/api/posts?id=' + id).then(r => r.json()).then(setPost)
     fetch('/api/comments?postId=' + id).then(r => r.json()).then(setComments)
     fetch('/api/session').then(r => r.json()).then(setUser)
+    fetch('/api/users').then(r => r.json()).then(list => {
+      const m = {}
+      list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl }))
+      setUsersMap(m)
+    })
   }, [id])
 
   async function addComment(e) {
@@ -46,9 +54,13 @@ export default function PostPage() {
   return (
     <div>
       <div className="bg-white rounded-lg shadow p-4 mt-4">
+        <div className="flex items-center gap-2 mb-2 text-sm text-gray-500">
+          <Avatar url={usersMap[post.userId]?.avatarUrl} size={24} />
+          <Link href={`/users/${post.userId}`}>{usersMap[post.userId]?.username || 'User'}</Link>
+        </div>
         <p className="mb-2">{post.content}</p>
         {post.imageUrl && <img src={post.imageUrl} alt="" className="mt-2 max-w-xs" />}
-        {post.videoUrl && <video src={post.videoUrl} controls className="mt-2 max-w-xs" />}
+        <VideoEmbed url={post.videoUrl} />
         <button onClick={likePost} className="block mt-2 bg-pink-500 text-white px-2 py-1 rounded">
           Like ({post.likes || 0})
         </button>
@@ -56,7 +68,10 @@ export default function PostPage() {
       <h2 className="text-xl font-bold mt-6">Comments</h2>
       <ul className="space-y-2">
         {comments.map(c => (
-          <li key={c.id} className="border p-2 rounded bg-white">{c.content}</li>
+          <li key={c.id} className="border p-2 rounded bg-white flex items-center gap-2">
+            <Avatar url={usersMap[c.userId]?.avatarUrl} size={24} />
+            <span>{c.content}</span>
+          </li>
         ))}
       </ul>
       {user && (

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,15 +1,24 @@
 import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import Avatar from '../components/Avatar'
+import VideoEmbed from '../components/VideoEmbed'
 
 export default function Profile() {
   const [profile, setProfile] = useState(null)
   const [avatar, setAvatar] = useState('')
+  const [posts, setPosts] = useState([])
 
   useEffect(() => {
     fetch('/api/profile')
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
         setProfile(data)
-        if (data && data.avatarUrl) setAvatar(data.avatarUrl)
+        if (data && data.avatarUrl) {
+          setAvatar(data.avatarUrl)
+          fetch('/api/posts?userId=' + data.id)
+            .then(r => r.json())
+            .then(setPosts)
+        }
       })
   }, [])
 
@@ -28,20 +37,38 @@ export default function Profile() {
   if (!profile) return <p className="mt-4">Please login first.</p>
 
   return (
-    <div className="max-w-sm mx-auto mt-6">
-      {profile.avatarUrl && (
-        <img src={profile.avatarUrl} alt="avatar" className="w-32 h-32 rounded-full mx-auto mb-4 object-cover" />
-      )}
-      <h1 className="text-xl font-bold text-center mb-4">{profile.username}</h1>
-      <form onSubmit={save} className="space-y-3 bg-white p-6 rounded shadow">
-        <input
-          value={avatar}
-          onChange={e => setAvatar(e.target.value)}
-          placeholder="Avatar URL"
-          className="border p-2 w-full rounded"
-        />
-        <button className="w-full bg-blue-500 text-white py-2 rounded" type="submit">Save</button>
+    <div className="max-w-lg mx-auto mt-6 space-y-6">
+      <div className="bg-white p-6 rounded shadow text-center">
+        <Avatar url={profile.avatarUrl} size={128} />
+        <h1 className="text-2xl font-bold mt-2">{profile.username}</h1>
+      </div>
+      <form onSubmit={save} className="flex gap-2 items-center">
+        <input type="file" onChange={e => {
+          const file = e.target.files[0]
+          if (file) {
+            const reader = new FileReader()
+            reader.onload = () => setAvatar(reader.result)
+            reader.readAsDataURL(file)
+          }
+        }} className="border p-2 rounded" />
+        <button className="bg-blue-500 text-white px-4 rounded" type="submit">Save</button>
       </form>
+      <div>
+        <h2 className="text-xl font-bold mb-2">Your Posts</h2>
+        <div className="space-y-4">
+          {posts.map(p => (
+            <div key={p.id} className="bg-white p-4 rounded shadow">
+              <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
+              <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
+                <Avatar url={profile.avatarUrl} size={24} />
+                <span>{profile.username}</span>
+              </div>
+              {p.imageUrl && <img src={p.imageUrl} alt="" className="mt-2 max-w-full" />}
+              <VideoEmbed url={p.videoUrl} />
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   )
 }

--- a/pages/trending.js
+++ b/pages/trending.js
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
+import Avatar from '../components/Avatar'
+import VideoEmbed from '../components/VideoEmbed'
 
 export default function Trending() {
   const [posts, setPosts] = useState([])
@@ -9,7 +11,7 @@ export default function Trending() {
     fetch('/api/posts?trending=1').then(r => r.json()).then(setPosts)
     fetch('/api/users').then(r => r.json()).then(list => {
       const m = {}
-      list.forEach(u => (m[u.id] = u.username))
+      list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl }))
       setUsersMap(m)
     })
   }, [])
@@ -29,13 +31,15 @@ export default function Trending() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Trending Posts</h1>
-      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+      <div className="space-y-4">
         {posts.map(p => (
           <div key={p.id} className="bg-white rounded-lg shadow p-3">
             <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
-            <div className="text-sm text-gray-500 mb-2">
-              by <Link href={`/users/${p.userId}`}>{usersMap[p.userId] || 'User'}</Link>
+            <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
+              <Avatar url={usersMap[p.userId]?.avatarUrl} size={24} />
+              <Link href={`/users/${p.userId}`}>{usersMap[p.userId]?.username || 'User'}</Link>
             </div>
+            <VideoEmbed url={p.videoUrl} />
             <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
               Like ({p.likes || 0})
             </button>

--- a/pages/users/[id].js
+++ b/pages/users/[id].js
@@ -1,6 +1,8 @@
 import { useRouter } from 'next/router'
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
+import Avatar from '../../components/Avatar'
+import VideoEmbed from '../../components/VideoEmbed'
 
 export default function UserPage() {
   const router = useRouter()
@@ -40,7 +42,10 @@ export default function UserPage() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mt-4">{profile.username}</h1>
+      <div className="flex items-center gap-3 mt-4">
+        <Avatar url={profile.avatarUrl} size={48} />
+        <h1 className="text-2xl font-bold">{profile.username}</h1>
+      </div>
       {user && user.id !== Number(id) && (
         isFollowing ? (
           <button onClick={unfollow} className="mt-2 bg-gray-300 px-2 rounded">Unfollow</button>
@@ -51,7 +56,12 @@ export default function UserPage() {
       <div className="mt-4 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
         {posts.map(p => (
           <div key={p.id} className="bg-white p-3 rounded-lg shadow">
-            <Link href={`/posts/${p.id}`}>{p.content}</Link>
+            <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
+            <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
+              <Avatar url={profile.avatarUrl} size={24} />
+              <span>{profile.username}</span>
+            </div>
+            <VideoEmbed url={p.videoUrl} />
           </div>
         ))}
       </div>

--- a/public/avatar-default.svg
+++ b/public/avatar-default.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="red" />
+  <text x="50" y="65" font-size="60" text-anchor="middle" fill="white">同心</text>
+</svg>


### PR DESCRIPTION
## Summary
- rename Feed page to Home and update navigation
- redesign post composer and recommendation section on the homepage
- restyle trending and profile pages
- refresh documentation for the new Home route
- add avatars, video embeds, and a default SVG icon for profiles

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_68535d20c734832aaf90148deb396b75