### PR TITLE
Enable threaded comment replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ TongXin ("One Heart") now runs on [Next.js](https://nextjs.org/) with API routes
 - Create, edit and delete posts with optional images and videos
 - Embed YouTube or Bilibili videos directly in posts
 - Comment on posts
+- Reply to comments in threaded conversations
 - Like posts and view a trending page
 - Follow other users and view profiles
 - Search posts and see simple recommendations

--- a/migrations/0003-comment-parent.js
+++ b/migrations/0003-comment-parent.js
@@ -1,0 +1,13 @@
+'use strict'
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Comments', 'parentId', {
+      type: Sequelize.INTEGER,
+      references: { model: 'Comments', key: 'id' },
+      allowNull: true
+    })
+  },
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Comments', 'parentId')
+  }
+}

--- a/models/comment.js
+++ b/models/comment.js
@@ -3,11 +3,14 @@ module.exports = (sequelize, DataTypes) => {
   const Comment = sequelize.define('Comment', {
     postId: { type: DataTypes.INTEGER, allowNull: false },
     userId: { type: DataTypes.INTEGER, allowNull: false },
+    parentId: DataTypes.INTEGER,
     content: DataTypes.TEXT
   })
   Comment.associate = models => {
     Comment.belongsTo(models.Post, { foreignKey: 'postId' })
     Comment.belongsTo(models.User, { foreignKey: 'userId' })
+    Comment.belongsTo(models.Comment, { foreignKey: 'parentId', as: 'parent' })
+    Comment.hasMany(models.Comment, { foreignKey: 'parentId', as: 'replies' })
   }
   return Comment
 }

--- a/pages/api/comments.js
+++ b/pages/api/comments.js
@@ -4,16 +4,31 @@ import db from '../../models'
 async function handler(req, res) {
   const { Comment } = db
   if (req.method === 'GET') {
-    const { postId } = req.query
-    const where = postId ? { postId } : {}
+    const { id, postId, parentId } = req.query
+    if (id) {
+      const comment = await Comment.findByPk(id)
+      return res.status(comment ? 200 : 404).json(comment || null)
+    }
+    const where = {}
+    if (postId) where.postId = postId
+    if (typeof parentId !== 'undefined') {
+      where.parentId = parentId === 'null' ? null : parentId
+    } else if (postId) {
+      where.parentId = null
+    }
     const result = await Comment.findAll({ where })
     return res.status(200).json(result)
   }
 
   if (req.method === 'POST') {
     if (!req.session.user) return res.status(401).end()
-    const { postId, content } = req.body
-    const comment = await Comment.create({ postId, userId: req.session.user.id, content })
+    const { postId, content, parentId } = req.body
+    const comment = await Comment.create({
+      postId,
+      userId: req.session.user.id,
+      content,
+      parentId: parentId || null
+    })
     return res.status(201).json(comment)
   }
 

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -16,7 +16,9 @@ export default function PostPage() {
   useEffect(() => {
     if (!id) return
     fetch('/api/posts?id=' + id).then(r => r.json()).then(setPost)
-    fetch('/api/comments?postId=' + id).then(r => r.json()).then(setComments)
+    fetch('/api/comments?postId=' + id + '&parentId=null')
+      .then(r => r.json())
+      .then(setComments)
     fetch('/api/session').then(r => r.json()).then(setUser)
     fetch('/api/users').then(r => r.json()).then(list => {
       const m = {}
@@ -76,6 +78,7 @@ export default function PostPage() {
                 <span>{new Date(c.createdAt).toLocaleString()}</span>
               </div>
               <p>{c.content}</p>
+              <Link href={`/thread/${c.id}`} className="text-blue-600 text-sm">Thread</Link>
             </div>
           </li>
         ))}

--- a/pages/thread/[id].js
+++ b/pages/thread/[id].js
@@ -1,0 +1,83 @@
+import { useRouter } from 'next/router'
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import Avatar from '../../components/Avatar'
+
+export default function ThreadPage() {
+  const router = useRouter()
+  const { id } = router.query
+  const [comment, setComment] = useState(null)
+  const [replies, setReplies] = useState([])
+  const [replyText, setReplyText] = useState('')
+  const [user, setUser] = useState(null)
+  const [usersMap, setUsersMap] = useState({})
+
+  useEffect(() => {
+    if (!id) return
+    fetch('/api/comments?id=' + id).then(r => r.json()).then(setComment)
+    fetch('/api/comments?parentId=' + id).then(r => r.json()).then(setReplies)
+    fetch('/api/session').then(r => r.json()).then(setUser)
+    fetch('/api/users').then(r => r.json()).then(list => {
+      const m = {}
+      list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl }))
+      setUsersMap(m)
+    })
+  }, [id])
+
+  async function addReply(e) {
+    e.preventDefault()
+    if (!user) return
+    const res = await fetch('/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ postId: comment.postId, parentId: id, content: replyText })
+    })
+    if (res.ok) {
+      const c = await res.json()
+      setReplies([...replies, c])
+      setReplyText('')
+    }
+  }
+
+  if (!comment) return <p>Loading...</p>
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Thread</h1>
+      <div className="border p-3 rounded bg-white flex gap-2 mb-4">
+        <Avatar url={usersMap[comment.userId]?.avatarUrl} size={32} />
+        <div className="flex-1">
+          <div className="flex items-center gap-2 text-sm text-gray-500">
+            <Link href={`/users/${comment.userId}`}>{usersMap[comment.userId]?.username || 'User'}</Link>
+            <span>{new Date(comment.createdAt).toLocaleString()}</span>
+          </div>
+          <p>{comment.content}</p>
+        </div>
+      </div>
+      <ul className="space-y-2">
+        {replies.map(r => (
+          <li key={r.id} className="border p-2 rounded bg-white flex gap-2">
+            <Avatar url={usersMap[r.userId]?.avatarUrl} size={32} />
+            <div className="flex-1">
+              <div className="flex items-center gap-2 text-sm text-gray-500">
+                <Link href={`/users/${r.userId}`}>{usersMap[r.userId]?.username || 'User'}</Link>
+                <span>{new Date(r.createdAt).toLocaleString()}</span>
+              </div>
+              <p>{r.content}</p>
+            </div>
+          </li>
+        ))}
+      </ul>
+      {user && (
+        <form onSubmit={addReply} className="mt-4 flex gap-2">
+          <input
+            value={replyText}
+            onChange={e => setReplyText(e.target.value)}
+            className="border p-1 flex-grow"
+          />
+          <button type="submit" className="bg-blue-500 text-white px-3 rounded">Reply</button>
+        </form>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- allow replying to comments and start threads
- expose `parentId` on comments via migration and model updates
- filter comments by parentId in the API
- show a thread link on post comments
- add a thread page to view and reply to comment threads
- document threaded comments in README

## Testing
- `npm install`
- `npx sequelize-cli db:migrate`
- `npm run dev &`
- `curl -I http://localhost:3001`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_68539fbc82c4832a9da40b2a59891003