### PR TITLE
Fix Capacitor init instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,9 @@ This project strives to follow applicable regulations and moderation requirement
 
 ## iOS and macOS apps
 
-This project can be packaged as a native application using [Capacitor](https://capacitorjs.com/). After installing the dependencies run:
+This project can be packaged as a native application using [Capacitor](https://capacitorjs.com/). A ready-made `capacitor.config.ts` is included, so after installing the dependencies (which now include TypeScript) run:
 
 ```bash
-npx cap init TongXin com.example.tongxin
 npm run build
 npx cap add ios
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "autoprefixer": "^10.4.17",
         "postcss": "^8.4.32",
         "sequelize-cli": "^6.6.1",
-        "tailwindcss": "^3.4.4"
+        "tailwindcss": "^3.4.4",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4727,6 +4728,20 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/umzug": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.4",
     "sequelize-cli": "^6.6.1",
+    "typescript": "^5.8.3",
     "@capacitor/cli": "^7.4.0",
     "@capacitor/ios": "^7.4.0",
     "@capacitor/electron": "^2.5.0"


### PR DESCRIPTION
## Summary
- install TypeScript so `capacitor.config.ts` works
- clarify README to skip `npx cap init`

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_68544dd13690832a869750a2625331c1