### PR TITLE
Add Electron packaging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,22 @@ npm run dev
 ```
 
 See the Capacitor documentation for details on code signing and App Store submission.
+
+## Desktop app (Electron)
+
+To package the app as a desktop application, Capacitor's Electron platform is included.
+After building the static files, add the Electron platform:
+
+```bash
+npm run build
+npx cap add electron
+```
+
+This creates an `electron` directory. Start the Next.js server and launch Electron during development:
+
+```bash
+npm run dev &
+npx cap open electron
+```
+
+Keep the server running so the desktop app can load the web content.

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Export the app as static HTML for Capacitor
+  output: 'export',
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## Summary
- document how to build the Electron desktop app
- export static HTML during Next.js builds for Capacitor

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_685453cb8ec0832aa474d11b21697a2c