### PR TITLE
Improve UI styling

### DIFF
--- a/components/ComposeForm.js
+++ b/components/ComposeForm.js
@@ -60,7 +60,7 @@ export default function ComposeForm({ onPost }) {
   if (!user) return null
 
   return (
-    <form onSubmit={createPost} className="mt-4 space-y-2 bg-white p-4 rounded shadow">
+    <form onSubmit={createPost} className="mt-6 space-y-3 bg-white p-4 rounded-lg shadow-md">
       <div className="flex gap-3">
         <Avatar url={profile?.avatarUrl} size={48} />
         <textarea
@@ -73,15 +73,17 @@ export default function ComposeForm({ onPost }) {
           }}
           onPaste={handlePaste}
           placeholder="What's happening?"
-          className="border p-2 w-full rounded resize-none focus:outline-none"
+          className="border border-gray-300 p-3 w-full rounded-md resize-none focus:ring focus:ring-blue-200"
         />
       </div>
       {imageUrl && (
-        <img src={imageUrl} alt="preview" className="w-24 h-24 object-cover rounded" />
+        <img src={imageUrl} alt="preview" className="w-full max-h-64 object-cover rounded-md" />
       )}
-      <button className="bg-blue-600 text-white px-4 py-2 rounded" type="submit">
-        Post
-      </button>
+      <div className="text-right">
+        <button className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md" type="submit">
+          Post
+        </button>
+      </div>
     </form>
   )
 }

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -14,9 +14,9 @@ export default function Layout({ children }) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="sticky top-0 bg-white shadow">
-        <div className="flex items-center justify-between p-4">
+    <div className="min-h-screen bg-gray-100 text-gray-800">
+      <header className="sticky top-0 bg-gradient-to-r from-blue-500 to-purple-500 text-white shadow">
+        <div className="flex items-center justify-between p-4 max-w-5xl mx-auto">
           <Link href="/" className="text-xl font-bold">TongXin</Link>
           <nav className="space-x-4 flex items-center">
             <Link href="/home">Home</Link>
@@ -26,7 +26,7 @@ export default function Layout({ children }) {
             {user ? (
               <>
                 <Link href="/profile">Profile</Link>
-                <button onClick={logout} className="ml-2 text-sm text-gray-600">Logout</button>
+                <button onClick={logout} className="ml-2 text-sm">Logout</button>
               </>
             ) : (
               <>
@@ -37,7 +37,7 @@ export default function Layout({ children }) {
           </nav>
         </div>
       </header>
-      <main className="w-full p-4">{children}</main>
+      <main className="w-full p-4 max-w-5xl mx-auto">{children}</main>
     </div>
   )
 }

--- a/pages/compose.js
+++ b/pages/compose.js
@@ -59,7 +59,7 @@ export default function Compose() {
 
   return (
     <div className="max-w-xl mx-auto mt-6">
-      <form onSubmit={createPost} className="bg-white rounded shadow p-4 flex gap-3">
+      <form onSubmit={createPost} className="bg-white rounded-lg shadow-md p-4 flex gap-3">
         <Avatar url={profile?.avatarUrl} size={48} />
         <div className="flex-1">
           <textarea
@@ -72,12 +72,12 @@ export default function Compose() {
             }}
             onPaste={handlePaste}
             placeholder="What's happening?"
-            className="w-full resize-none focus:outline-none border-b border-gray-300 p-2"
+            className="w-full resize-none border-b border-gray-300 p-3 focus:ring focus:ring-blue-200"
           />
           {imageUrl && (
-            <img src={imageUrl} alt="preview" className="w-32 h-32 object-cover rounded mt-2" />
+            <img src={imageUrl} alt="preview" className="w-32 h-32 object-cover rounded-md mt-2" />
           )}
-          <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded mt-3 float-right">
+          <button type="submit" className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md mt-3 float-right">
             Post
           </button>
         </div>

--- a/pages/home.js
+++ b/pages/home.js
@@ -35,14 +35,14 @@ export default function HomePage() {
       <ComposeForm onPost={post => setPosts([post, ...posts])} />
       <div className="space-y-4">
         {posts.map(p => (
-          <div key={p.id} className="bg-white p-3 rounded-lg shadow">
+          <div key={p.id} className="bg-white p-4 rounded-lg shadow hover:shadow-lg transition">
             <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
             <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
               <Avatar url={usersMap[p.userId]?.avatarUrl} size={24} />
               <Link href={`/users/${p.userId}`}>{usersMap[p.userId]?.username || 'User'}</Link>
             </div>
             <VideoEmbed url={p.videoUrl} />
-            <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
+            <button onClick={() => like(p.id)} className="mt-2 bg-pink-500 hover:bg-pink-600 text-white px-3 py-1 rounded-md">
               Like ({p.likes || 0})
             </button>
           </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -37,11 +37,11 @@ export default function Home() {
       <ComposeForm onPost={post => setPosts([post, ...posts])} />
       <div className="space-y-4 mt-6">
         {posts.map(p => (
-          <div key={p.id} className="bg-white rounded-lg shadow overflow-hidden">
+          <div key={p.id} className="bg-white rounded-lg shadow hover:shadow-lg transition overflow-hidden">
             {p.imageUrl && (
               <img src={p.imageUrl} alt="" className="w-full h-48 object-cover" />
             )}
-            <div className="p-3">
+            <div className="p-4">
               <Link href={`/posts/${p.id}`} className="font-medium block mb-1">
                 {p.content}
               </Link>
@@ -52,7 +52,7 @@ export default function Home() {
               <VideoEmbed url={p.videoUrl} />
               <button
                 onClick={() => like(p.id)}
-                className="bg-pink-500 text-white px-2 py-1 rounded"
+                className="mt-2 bg-pink-500 hover:bg-pink-600 text-white px-3 py-1 rounded-md"
               >
                 Like ({p.likes || 0})
               </button>

--- a/pages/login.js
+++ b/pages/login.js
@@ -19,22 +19,22 @@ export default function Login() {
   }
 
   return (
-    <div className="flex justify-center mt-8">
-      <form onSubmit={login} className="space-y-3 bg-white p-6 rounded shadow w-full max-w-sm">
+    <div className="flex justify-center mt-10">
+      <form onSubmit={login} className="space-y-4 bg-white p-8 rounded-lg shadow-md w-full max-w-sm">
         <input
           value={username}
           onChange={e => setUsername(e.target.value)}
           placeholder="username"
-          className="border p-2 w-full rounded"
+          className="border border-gray-300 p-3 w-full rounded-md focus:ring focus:ring-blue-200"
         />
         <input
           type="password"
           value={password}
           onChange={e => setPassword(e.target.value)}
           placeholder="password"
-          className="border p-2 w-full rounded"
+          className="border border-gray-300 p-3 w-full rounded-md focus:ring focus:ring-blue-200"
         />
-        <button className="w-full bg-blue-500 text-white py-2 rounded" type="submit">Login</button>
+        <button className="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded-md" type="submit">Login</button>
       </form>
     </div>
   )

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -55,15 +55,15 @@ export default function PostPage() {
 
   return (
     <div>
-      <div className="bg-white rounded-lg shadow p-4 mt-4">
+      <div className="bg-white rounded-lg shadow hover:shadow-lg transition p-4 mt-4">
         <div className="flex items-center gap-2 mb-2 text-sm text-gray-500">
           <Avatar url={usersMap[post.userId]?.avatarUrl} size={24} />
           <Link href={`/users/${post.userId}`}>{usersMap[post.userId]?.username || 'User'}</Link>
         </div>
         <p className="mb-2">{post.content}</p>
-        {post.imageUrl && <img src={post.imageUrl} alt="" className="mt-2 max-w-xs" />}
+        {post.imageUrl && <img src={post.imageUrl} alt="" className="mt-2 max-w-xs rounded-md" />}
         <VideoEmbed url={post.videoUrl} />
-        <button onClick={likePost} className="block mt-2 bg-pink-500 text-white px-2 py-1 rounded">
+        <button onClick={likePost} className="block mt-2 bg-pink-500 hover:bg-pink-600 text-white px-3 py-1 rounded-md">
           Like ({post.likes || 0})
         </button>
       </div>
@@ -90,9 +90,9 @@ export default function PostPage() {
             onChange={e => setCommentText(e.target.value)}
             rows="3"
             placeholder="Write a comment..."
-            className="border p-2 flex-grow rounded resize-none focus:outline-none"
+            className="border border-gray-300 p-2 flex-grow rounded-md resize-none focus:ring focus:ring-blue-200"
           />
-          <button type="submit" className="bg-blue-500 text-white px-3 rounded">Add</button>
+          <button type="submit" className="bg-blue-600 hover:bg-blue-700 text-white px-4 rounded-md">Add</button>
         </form>
       )}
     </div>

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -38,7 +38,7 @@ export default function Profile() {
 
   return (
     <div className="max-w-lg mx-auto mt-6 space-y-6">
-      <div className="bg-white p-6 rounded shadow text-center">
+      <div className="bg-white p-6 rounded-lg shadow-md text-center">
         <Avatar url={profile.avatarUrl} size={128} />
         <h1 className="text-2xl font-bold mt-2">{profile.username}</h1>
       </div>
@@ -50,20 +50,20 @@ export default function Profile() {
             reader.onload = () => setAvatar(reader.result)
             reader.readAsDataURL(file)
           }
-        }} className="border p-2 rounded" />
-        <button className="bg-blue-500 text-white px-4 rounded" type="submit">Save</button>
+        }} className="border border-gray-300 p-2 rounded-md" />
+        <button className="bg-blue-600 hover:bg-blue-700 text-white px-4 rounded-md" type="submit">Save</button>
       </form>
       <div>
         <h2 className="text-xl font-bold mb-2">Your Posts</h2>
         <div className="space-y-4">
           {posts.map(p => (
-            <div key={p.id} className="bg-white p-4 rounded shadow">
+            <div key={p.id} className="bg-white p-4 rounded-lg shadow hover:shadow-lg transition">
               <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
               <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
                 <Avatar url={profile.avatarUrl} size={24} />
                 <span>{profile.username}</span>
               </div>
-              {p.imageUrl && <img src={p.imageUrl} alt="" className="mt-2 max-w-full" />}
+              {p.imageUrl && <img src={p.imageUrl} alt="" className="mt-2 max-w-full rounded-md" />}
               <VideoEmbed url={p.videoUrl} />
             </div>
           ))}

--- a/pages/register.js
+++ b/pages/register.js
@@ -24,22 +24,22 @@ export default function Register() {
   }
 
   return (
-    <div className="flex justify-center mt-8">
-      <form onSubmit={register} className="space-y-3 bg-white p-6 rounded shadow w-full max-w-sm">
+    <div className="flex justify-center mt-10">
+      <form onSubmit={register} className="space-y-4 bg-white p-8 rounded-lg shadow-md w-full max-w-sm">
         <input
           value={username}
           onChange={e => setUsername(e.target.value)}
           placeholder="username"
-          className="border p-2 w-full rounded"
+          className="border border-gray-300 p-3 w-full rounded-md focus:ring focus:ring-blue-200"
         />
         <input
           type="password"
           value={password}
           onChange={e => setPassword(e.target.value)}
           placeholder="password"
-          className="border p-2 w-full rounded"
+          className="border border-gray-300 p-3 w-full rounded-md focus:ring focus:ring-blue-200"
         />
-        <button className="w-full bg-green-500 text-white py-2 rounded" type="submit">Register</button>
+        <button className="w-full bg-green-600 hover:bg-green-700 text-white py-2 rounded-md" type="submit">Register</button>
       </form>
     </div>
   )

--- a/pages/search.js
+++ b/pages/search.js
@@ -33,17 +33,21 @@ export default function Search() {
     <div>
       <h1 className="text-2xl font-bold mb-4">Search Posts</h1>
       <form onSubmit={doSearch} className="my-4 flex gap-2">
-        <input value={q} onChange={e => setQ(e.target.value)} className="border p-1 flex-grow" />
-        <button className="px-3 py-1 bg-blue-500 text-white rounded" type="submit">Search</button>
+        <input
+          value={q}
+          onChange={e => setQ(e.target.value)}
+          className="border border-gray-300 p-2 rounded-md flex-grow"
+        />
+        <button className="px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-md" type="submit">Search</button>
       </form>
       <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
         {posts.map(p => (
-          <div key={p.id} className="bg-white p-3 rounded-lg shadow">
+          <div key={p.id} className="bg-white p-4 rounded-lg shadow hover:shadow-lg transition">
             <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
             <div className="text-sm text-gray-500 mb-2">
               by <Link href={`/users/${p.userId}`}>{usersMap[p.userId] || 'User'}</Link>
             </div>
-            <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
+            <button onClick={() => like(p.id)} className="mt-2 bg-pink-500 hover:bg-pink-600 text-white px-3 py-1 rounded-md">
               Like ({p.likes || 0})
             </button>
           </div>

--- a/pages/thread/[id].js
+++ b/pages/thread/[id].js
@@ -44,7 +44,7 @@ export default function ThreadPage() {
   return (
     <div>
       <h1 className="text-xl font-bold mb-4">Thread</h1>
-      <div className="border p-3 rounded bg-white flex gap-2 mb-4">
+      <div className="border p-3 rounded-lg bg-white flex gap-2 mb-4 shadow">
         <Avatar url={usersMap[comment.userId]?.avatarUrl} size={32} />
         <div className="flex-1">
           <div className="flex items-center gap-2 text-sm text-gray-500">
@@ -56,7 +56,7 @@ export default function ThreadPage() {
       </div>
       <ul className="space-y-2 border-l-2 border-gray-200 pl-4">
         {replies.map(r => (
-          <li key={r.id} className="border p-2 rounded bg-white flex gap-2">
+          <li key={r.id} className="border p-2 rounded-lg bg-white flex gap-2 shadow">
             <Avatar url={usersMap[r.userId]?.avatarUrl} size={32} />
             <div className="flex-1">
               <div className="flex items-center gap-2 text-sm text-gray-500">
@@ -75,9 +75,9 @@ export default function ThreadPage() {
             onChange={e => setReplyText(e.target.value)}
             rows="3"
             placeholder="Write a reply..."
-            className="border p-2 flex-grow rounded resize-none focus:outline-none"
+            className="border border-gray-300 p-2 flex-grow rounded-md resize-none focus:ring focus:ring-blue-200"
           />
-          <button type="submit" className="bg-blue-500 text-white px-3 rounded">Reply</button>
+          <button type="submit" className="bg-blue-600 hover:bg-blue-700 text-white px-4 rounded-md">Reply</button>
         </form>
       )}
     </div>

--- a/pages/trending.js
+++ b/pages/trending.js
@@ -33,14 +33,14 @@ export default function Trending() {
       <h1 className="text-2xl font-bold mb-4">Trending Posts</h1>
       <div className="space-y-4">
         {posts.map(p => (
-          <div key={p.id} className="bg-white rounded-lg shadow p-3">
+          <div key={p.id} className="bg-white rounded-lg shadow hover:shadow-lg transition p-4">
             <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
             <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
               <Avatar url={usersMap[p.userId]?.avatarUrl} size={24} />
               <Link href={`/users/${p.userId}`}>{usersMap[p.userId]?.username || 'User'}</Link>
             </div>
             <VideoEmbed url={p.videoUrl} />
-            <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
+            <button onClick={() => like(p.id)} className="mt-2 bg-pink-500 hover:bg-pink-600 text-white px-3 py-1 rounded-md">
               Like ({p.likes || 0})
             </button>
           </div>

--- a/pages/users/[id].js
+++ b/pages/users/[id].js
@@ -48,14 +48,14 @@ export default function UserPage() {
       </div>
       {user && user.id !== Number(id) && (
         isFollowing ? (
-          <button onClick={unfollow} className="mt-2 bg-gray-300 px-2 rounded">Unfollow</button>
+          <button onClick={unfollow} className="mt-2 bg-gray-300 px-3 py-1 rounded-md">Unfollow</button>
         ) : (
-          <button onClick={follow} className="mt-2 bg-blue-500 text-white px-2 rounded">Follow</button>
+          <button onClick={follow} className="mt-2 bg-blue-600 text-white px-3 py-1 rounded-md">Follow</button>
         )
       )}
       <div className="mt-4 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
         {posts.map(p => (
-          <div key={p.id} className="bg-white p-3 rounded-lg shadow">
+          <div key={p.id} className="bg-white p-4 rounded-lg shadow hover:shadow-lg transition">
             <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
             <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
               <Avatar url={profile.avatarUrl} size={24} />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply p-5 font-sans;
+  @apply p-5 font-sans bg-gray-100;
 }


### PR DESCRIPTION
## Summary
- add gradient header and wider layout
- enhance compose form styling
- refine cards and buttons on index page
- restyle forms and components across pages

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_68545d72b5b4832abb7de3b23805de87