### PR TITLE
Add short video upload and infinite scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ TongXin ("One Heart") now runs on [Next.js](https://nextjs.org/) with API routes
 - User registration and login with hashed passwords
 - Create, edit and delete posts with optional images and videos
 - Embed YouTube or Bilibili videos directly in posts
+- Upload short videos and watch them in an infinite scrolling feed at `/shorts`
 - Comment on posts
 - Reply to comments in threaded conversations
 - Like posts and view a trending page
@@ -47,6 +48,7 @@ Visit `http://localhost:3000` to use the app. The homepage shows your feed and r
 - `/posts/[id]` - view a single post with comments
 - `/users/[id]` - view a user profile
 - `/compose` - create a new post
+- `/shorts` - scroll through short videos endlessly
 
 ## Compliance
 

--- a/components/ComposeForm.js
+++ b/components/ComposeForm.js
@@ -79,6 +79,21 @@ export default function ComposeForm({ onPost }) {
       {imageUrl && (
         <img src={imageUrl} alt="preview" className="w-24 h-24 object-cover rounded" />
       )}
+      {videoUrl && (
+        <video src={videoUrl} controls className="w-24 h-24 rounded" />
+      )}
+      <input
+        type="file"
+        accept="video/*"
+        onChange={e => {
+          const file = e.target.files[0]
+          if (file) {
+            const reader = new FileReader()
+            reader.onload = () => setVideoUrl(reader.result)
+            reader.readAsDataURL(file)
+          }
+        }}
+      />
       <button className="bg-blue-600 text-white px-4 py-2 rounded" type="submit">
         Post
       </button>

--- a/components/VideoEmbed.js
+++ b/components/VideoEmbed.js
@@ -1,6 +1,8 @@
 export default function VideoEmbed({ url }) {
   if (!url) return null
-  const yt = url.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/))([^?&]+)/)
+  const yt = url.match(
+    /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|shorts\/))([^?&/]+)/
+  )
   if (yt) {
     const start = url.match(/[?&]t=(\d+)/)
     const param = start ? `?start=${start[1]}` : ''
@@ -14,6 +16,19 @@ export default function VideoEmbed({ url }) {
       />
     )
   }
+
+  const tk = url.match(/tiktok\.com\/.+\/video\/(\d+)/)
+  if (tk) {
+    return (
+      <iframe
+        src={`https://www.tiktok.com/embed/v2/${tk[1]}`}
+        className="w-full mb-2"
+        height="560"
+        allowFullScreen
+      />
+    )
+  }
+
   const bv = url.match(/bilibili\.com\/video\/([a-zA-Z0-9]+)/)
   if (bv) {
     return (
@@ -25,5 +40,18 @@ export default function VideoEmbed({ url }) {
       />
     )
   }
+
+  const xhs = url.match(/xiaohongshu\.com\/([a-zA-Z0-9]+)/)
+  if (xhs) {
+    return (
+      <iframe
+        src={`https://www.xiaohongshu.com/embed/${xhs[1]}`}
+        className="w-full mb-2"
+        height="560"
+        allowFullScreen
+      />
+    )
+  }
+
   return <video src={url} controls className="w-full mb-2" />
 }

--- a/pages/api/posts.js
+++ b/pages/api/posts.js
@@ -12,7 +12,7 @@ async function handler(req, res) {
 
     let where = {}
     if (req.query.userId) where.userId = req.query.userId
-    let result = await Post.findAll({ where })
+    let result = await Post.findAll({ where, order: [['createdAt', 'DESC']] })
 
     if (req.query.q) {
       const q = req.query.q.toLowerCase()
@@ -25,11 +25,19 @@ async function handler(req, res) {
       result = result.filter(p => ids.includes(p.userId))
     }
 
+    if (req.query.video) {
+      result = result.filter(p => p.videoUrl)
+    }
+
     if (req.query.trending) {
       result = [...result].sort((a, b) => (b.likes || 0) - (a.likes || 0))
     }
 
-    return res.status(200).json(result)
+    const offset = parseInt(req.query.offset || '0', 10)
+    const limit = parseInt(req.query.limit || result.length, 10)
+    const slice = result.slice(offset, offset + limit)
+
+    return res.status(200).json(slice)
   }
 
   if (req.method === 'POST') {

--- a/pages/compose.js
+++ b/pages/compose.js
@@ -72,14 +72,30 @@ export default function Compose() {
             }}
             onPaste={handlePaste}
             placeholder="What's happening?"
-            className="w-full resize-none focus:outline-none border-b border-gray-300 p-2"
-          />
-          {imageUrl && (
-            <img src={imageUrl} alt="preview" className="w-32 h-32 object-cover rounded mt-2" />
-          )}
-          <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded mt-3 float-right">
-            Post
-          </button>
+          className="w-full resize-none focus:outline-none border-b border-gray-300 p-2"
+        />
+        {imageUrl && (
+          <img src={imageUrl} alt="preview" className="w-32 h-32 object-cover rounded mt-2" />
+        )}
+        {videoUrl && (
+          <video src={videoUrl} controls className="w-32 h-32 rounded mt-2" />
+        )}
+        <input
+          type="file"
+          accept="video/*"
+          onChange={e => {
+            const file = e.target.files[0]
+            if (file) {
+              const reader = new FileReader()
+              reader.onload = () => setVideoUrl(reader.result)
+              reader.readAsDataURL(file)
+            }
+          }}
+          className="mt-2"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded mt-3 float-right">
+          Post
+        </button>
         </div>
       </form>
     </div>

--- a/pages/shorts.js
+++ b/pages/shorts.js
@@ -1,0 +1,73 @@
+import { useState, useEffect, useRef } from 'react'
+import Link from 'next/link'
+import Avatar from '../components/Avatar'
+import VideoEmbed from '../components/VideoEmbed'
+import ComposeForm from '../components/ComposeForm'
+
+export default function Shorts() {
+  const [posts, setPosts] = useState([])
+  const [usersMap, setUsersMap] = useState({})
+  const [offset, setOffset] = useState(0)
+  const loader = useRef(null)
+  const limit = 5
+
+  useEffect(() => {
+    fetch('/api/users').then(r => r.json()).then(list => {
+      const m = {}
+      list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl }))
+      setUsersMap(m)
+    })
+    load()
+  }, [])
+
+  async function load() {
+    const res = await fetch(`/api/posts?video=1&offset=${offset}&limit=${limit}`)
+    if (res.ok) {
+      const data = await res.json()
+      setPosts(p => [...p, ...data])
+      setOffset(o => o + limit)
+    }
+  }
+
+  useEffect(() => {
+    const obs = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting) load()
+    })
+    if (loader.current) obs.observe(loader.current)
+    return () => obs.disconnect()
+  }, [loader.current])
+
+  async function like(id) {
+    const res = await fetch('/api/likes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id })
+    })
+    if (res.ok) {
+      const updated = await res.json()
+      setPosts(ps => ps.map(p => (p.id === id ? updated : p)))
+    }
+  }
+
+  return (
+    <div>
+      <ComposeForm onPost={post => setPosts([post, ...posts])} />
+      <div className="space-y-6 mt-4">
+        {posts.map(p => (
+          <div key={p.id} className="bg-white rounded shadow p-3">
+            <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
+              <Avatar url={usersMap[p.userId]?.avatarUrl} size={24} />
+              <Link href={`/users/${p.userId}`}>{usersMap[p.userId]?.username || 'User'}</Link>
+            </div>
+            <VideoEmbed url={p.videoUrl} />
+            <p className="mt-2 mb-2">{p.content}</p>
+            <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
+              Like ({p.likes || 0})
+            </button>
+          </div>
+        ))}
+        <div ref={loader} className="h-6" />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- support TikTok, Xiaohongshu and YouTube Shorts embedding
- allow uploading videos in compose form
- same upload support on compose page
- paginate `/api/posts` and add `video` filter
- add new `/shorts` page with infinite scroll
- document the new feature and page

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_68546f923e8c832a8ae57d8a42938bbb