### PR TITLE
Increase post API body size

### DIFF
--- a/pages/api/posts.js
+++ b/pages/api/posts.js
@@ -77,3 +77,11 @@ async function handler(req, res) {
 }
 
 export default withSessionRoute(handler)
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '10mb'
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- allow up to 10MB request bodies for posting

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_685479044704832abeea4fcf17369d33