### PR TITLE
Fix like rules and improve posts

### DIFF
--- a/components/ComposeForm.js
+++ b/components/ComposeForm.js
@@ -7,6 +7,7 @@ export default function ComposeForm({ onPost }) {
   const [content, setContent] = useState('')
   const [imageUrl, setImageUrl] = useState('')
   const [videoUrl, setVideoUrl] = useState('')
+  const [location, setLocation] = useState('')
 
   useEffect(() => {
     fetch('/api/session')
@@ -17,6 +18,12 @@ export default function ComposeForm({ onPost }) {
           fetch('/api/profile').then(r => r.json()).then(setProfile)
         }
       })
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(pos => {
+        const { latitude, longitude } = pos.coords
+        setLocation(`${latitude.toFixed(6)},${longitude.toFixed(6)}`)
+      })
+    }
   }, [])
 
   async function createPost(e) {
@@ -25,7 +32,7 @@ export default function ComposeForm({ onPost }) {
     const res = await fetch('/api/posts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ content, imageUrl, videoUrl })
+      body: JSON.stringify({ content, imageUrl, videoUrl, location })
     })
     if (res.ok) {
       const data = await res.json()
@@ -35,12 +42,20 @@ export default function ComposeForm({ onPost }) {
         content,
         imageUrl,
         videoUrl,
-        likes: 0
+        likes: 0,
+        location
       }
       if (onPost) onPost(post)
       setContent('')
       setImageUrl('')
       setVideoUrl('')
+      setLocation('')
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(pos => {
+          const { latitude, longitude } = pos.coords
+          setLocation(`${latitude.toFixed(6)},${longitude.toFixed(6)}`)
+        })
+      }
     }
   }
 

--- a/migrations/0004-likes.js
+++ b/migrations/0004-likes.js
@@ -1,0 +1,28 @@
+'use strict'
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('Likes', {
+      id: { type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true },
+      userId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'Users', key: 'id' }
+      },
+      postId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+        references: { model: 'Posts', key: 'id' }
+      },
+      createdAt: { type: Sequelize.DATE, allowNull: false },
+      updatedAt: { type: Sequelize.DATE, allowNull: false }
+    })
+    await queryInterface.addConstraint('Likes', {
+      fields: ['userId', 'postId'],
+      type: 'unique',
+      name: 'likes_user_post_unique'
+    })
+  },
+  async down(queryInterface) {
+    await queryInterface.dropTable('Likes')
+  }
+}

--- a/migrations/0005-post-location.js
+++ b/migrations/0005-post-location.js
@@ -1,0 +1,9 @@
+'use strict'
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Posts', 'location', Sequelize.STRING)
+  },
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Posts', 'location')
+  }
+}

--- a/models/index.js
+++ b/models/index.js
@@ -9,8 +9,9 @@ const User = require('./user')(sequelize, Sequelize.DataTypes)
 const Post = require('./post')(sequelize, Sequelize.DataTypes)
 const Comment = require('./comment')(sequelize, Sequelize.DataTypes)
 const Follow = require('./follow')(sequelize, Sequelize.DataTypes)
+const Like = require('./like')(sequelize, Sequelize.DataTypes)
 
-const db = { User, Post, Comment, Follow, sequelize }
+const db = { User, Post, Comment, Follow, Like, sequelize }
 
 Object.values(db).forEach(model => {
   if (model && model.associate) model.associate(db)

--- a/models/like.js
+++ b/models/like.js
@@ -1,0 +1,12 @@
+'use strict'
+module.exports = (sequelize, DataTypes) => {
+  const Like = sequelize.define('Like', {
+    userId: { type: DataTypes.INTEGER, allowNull: false },
+    postId: { type: DataTypes.INTEGER, allowNull: false }
+  })
+  Like.associate = models => {
+    Like.belongsTo(models.User, { foreignKey: 'userId' })
+    Like.belongsTo(models.Post, { foreignKey: 'postId' })
+  }
+  return Like
+}

--- a/models/post.js
+++ b/models/post.js
@@ -5,11 +5,13 @@ module.exports = (sequelize, DataTypes) => {
     content: DataTypes.TEXT,
     imageUrl: DataTypes.STRING,
     videoUrl: DataTypes.STRING,
+    location: DataTypes.STRING,
     likes: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 }
   })
   Post.associate = models => {
     Post.belongsTo(models.User, { foreignKey: 'userId' })
     Post.hasMany(models.Comment, { foreignKey: 'postId' })
+    Post.hasMany(models.Like, { foreignKey: 'postId' })
   }
   return Post
 }

--- a/pages/api/likes.js
+++ b/pages/api/likes.js
@@ -3,12 +3,19 @@ import db from '../../models'
 
 async function handler(req, res) {
   if (!req.session.user) return res.status(401).end()
-  const { Post } = db
+  const { Post, Like } = db
   const { id } = req.body
   const post = await Post.findByPk(id)
   if (!post) return res.status(404).end()
-  post.likes += 1
-  await post.save()
+  if (post.userId === req.session.user.id) return res.status(403).end()
+  const [like, created] = await Like.findOrCreate({
+    where: { userId: req.session.user.id, postId: id },
+    defaults: { userId: req.session.user.id, postId: id }
+  })
+  if (created) {
+    post.likes += 1
+    await post.save()
+  }
   res.status(200).json(post)
 }
 

--- a/pages/api/posts.js
+++ b/pages/api/posts.js
@@ -42,24 +42,26 @@ async function handler(req, res) {
 
   if (req.method === 'POST') {
     if (!req.session.user) return res.status(401).end()
-    const { content, imageUrl, videoUrl } = req.body
+    const { content, imageUrl, videoUrl, location } = req.body
     const post = await Post.create({
       userId: req.session.user.id,
       content,
       imageUrl,
-      videoUrl
+      videoUrl,
+      location
     })
     return res.status(201).json({ id: post.id })
   }
 
   if (req.method === 'PUT') {
     if (!req.session.user) return res.status(401).end()
-    const { id, content, imageUrl, videoUrl } = req.body
+    const { id, content, imageUrl, videoUrl, location } = req.body
     const post = await Post.findByPk(id)
     if (!post || post.userId !== req.session.user.id) return res.status(404).end()
     post.content = content
     post.imageUrl = imageUrl
     post.videoUrl = videoUrl
+    post.location = location
     await post.save()
     return res.status(200).json(post)
   }

--- a/pages/home.js
+++ b/pages/home.js
@@ -40,6 +40,8 @@ export default function HomePage() {
             <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
               <Avatar url={usersMap[p.userId]?.avatarUrl} size={24} />
               <Link href={`/users/${p.userId}`}>{usersMap[p.userId]?.username || 'User'}</Link>
+              <span>{new Date(p.createdAt).toLocaleString()}</span>
+              {p.location && <span>{p.location}</span>}
             </div>
             <VideoEmbed url={p.videoUrl} />
             <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">

--- a/pages/index.js
+++ b/pages/index.js
@@ -48,6 +48,8 @@ export default function Home() {
               <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
                 <Avatar url={usersMap[p.userId]?.avatarUrl} size={24} />
                 <Link href={`/users/${p.userId}`}>{usersMap[p.userId]?.username || 'User'}</Link>
+                <span>{new Date(p.createdAt).toLocaleString()}</span>
+                {p.location && <span>{p.location}</span>}
               </div>
               <VideoEmbed url={p.videoUrl} />
               <button

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -12,10 +12,23 @@ export default function PostPage() {
   const [commentText, setCommentText] = useState('')
   const [user, setUser] = useState(null)
   const [usersMap, setUsersMap] = useState({})
+  const [editing, setEditing] = useState(false)
+  const [formContent, setFormContent] = useState('')
+  const [formImage, setFormImage] = useState('')
+  const [formVideo, setFormVideo] = useState('')
+  const [formLocation, setFormLocation] = useState('')
 
   useEffect(() => {
     if (!id) return
-    fetch('/api/posts?id=' + id).then(r => r.json()).then(setPost)
+    fetch('/api/posts?id=' + id)
+      .then(r => r.json())
+      .then(p => {
+        setPost(p)
+        setFormContent(p.content || '')
+        setFormImage(p.imageUrl || '')
+        setFormVideo(p.videoUrl || '')
+        setFormLocation(p.location || '')
+      })
     fetch('/api/comments?postId=' + id + '&parentId=null')
       .then(r => r.json())
       .then(setComments)
@@ -26,6 +39,15 @@ export default function PostPage() {
       setUsersMap(m)
     })
   }, [id])
+
+  useEffect(() => {
+    if (editing && navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(pos => {
+        const { latitude, longitude } = pos.coords
+        setFormLocation(`${latitude.toFixed(6)},${longitude.toFixed(6)}`)
+      })
+    }
+  }, [editing])
 
   async function addComment(e) {
     e.preventDefault()
@@ -59,13 +81,93 @@ export default function PostPage() {
         <div className="flex items-center gap-2 mb-2 text-sm text-gray-500">
           <Avatar url={usersMap[post.userId]?.avatarUrl} size={24} />
           <Link href={`/users/${post.userId}`}>{usersMap[post.userId]?.username || 'User'}</Link>
+          <span>{new Date(post.createdAt).toLocaleString()}</span>
+          {post.location && <span>{post.location}</span>}
         </div>
-        <p className="mb-2">{post.content}</p>
-        {post.imageUrl && <img src={post.imageUrl} alt="" className="mt-2 max-w-xs" />}
-        <VideoEmbed url={post.videoUrl} />
-        <button onClick={likePost} className="block mt-2 bg-pink-500 text-white px-2 py-1 rounded">
-          Like ({post.likes || 0})
-        </button>
+        {editing ? (
+          <div className="space-y-2">
+            <textarea
+              value={formContent}
+              onChange={e => setFormContent(e.target.value)}
+              className="border p-2 w-full"
+            />
+            <input
+              value={formImage}
+              onChange={e => setFormImage(e.target.value)}
+              placeholder="Image URL"
+              className="border p-1 w-full"
+            />
+            <input
+              value={formVideo}
+              onChange={e => setFormVideo(e.target.value)}
+              placeholder="Video URL"
+              className="border p-1 w-full"
+            />
+            <button
+              onClick={async () => {
+                const res = await fetch('/api/posts', {
+                  method: 'PUT',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                    id,
+                    content: formContent,
+                    imageUrl: formImage,
+                    videoUrl: formVideo,
+                    location: formLocation
+                  })
+                })
+                if (res.ok) {
+                  setPost(await res.json())
+                  setEditing(false)
+                }
+              }}
+              className="bg-blue-500 text-white px-2 py-1 rounded"
+            >
+              Save
+            </button>
+            <button onClick={() => setEditing(false)} className="ml-2 text-sm">Cancel</button>
+          </div>
+        ) : (
+          <>
+            <p className="mb-2">{post.content}</p>
+            {post.imageUrl && <img src={post.imageUrl} alt="" className="mt-2 max-w-xs" />}
+            <VideoEmbed url={post.videoUrl} />
+            <button onClick={likePost} className="block mt-2 bg-pink-500 text-white px-2 py-1 rounded">
+              Like ({post.likes || 0})
+            </button>
+            {user && user.id === post.userId && (
+              <div className="mt-2 space-x-2 text-sm">
+                <button
+                  onClick={() => {
+                    setEditing(true)
+                    if (navigator.geolocation) {
+                      navigator.geolocation.getCurrentPosition(pos => {
+                        const { latitude, longitude } = pos.coords
+                        setFormLocation(`${latitude.toFixed(6)},${longitude.toFixed(6)}`)
+                      })
+                    }
+                  }}
+                  className="text-blue-600"
+                >
+                  Edit
+                </button>
+                <button
+                  onClick={async () => {
+                    const res = await fetch('/api/posts', {
+                      method: 'DELETE',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ id })
+                    })
+                    if (res.ok) router.push('/profile')
+                  }}
+                  className="text-red-600"
+                >
+                  Delete
+                </button>
+              </div>
+            )}
+          </>
+        )}
       </div>
       <h2 className="text-xl font-bold mt-6">Comments</h2>
       <ul className="space-y-2">

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -62,9 +62,27 @@ export default function Profile() {
               <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
                 <Avatar url={profile.avatarUrl} size={24} />
                 <span>{profile.username}</span>
+                <span>{new Date(p.createdAt).toLocaleString()}</span>
+                {p.location && <span>{p.location}</span>}
               </div>
               {p.imageUrl && <img src={p.imageUrl} alt="" className="mt-2 max-w-full" />}
               <VideoEmbed url={p.videoUrl} />
+              <div className="mt-2 space-x-2 text-sm">
+                <Link href={`/posts/${p.id}`}>View</Link>
+                <button
+                  onClick={async () => {
+                    const res = await fetch('/api/posts', {
+                      method: 'DELETE',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ id: p.id })
+                    })
+                    if (res.ok) setPosts(posts.filter(x => x.id !== p.id))
+                  }}
+                  className="text-red-600"
+                >
+                  Delete
+                </button>
+              </div>
             </div>
           ))}
         </div>

--- a/pages/search.js
+++ b/pages/search.js
@@ -42,6 +42,8 @@ export default function Search() {
             <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
             <div className="text-sm text-gray-500 mb-2">
               by <Link href={`/users/${p.userId}`}>{usersMap[p.userId] || 'User'}</Link>
+              <span className="ml-1">{new Date(p.createdAt).toLocaleString()}</span>
+              {p.location && <span className="ml-1">{p.location}</span>}
             </div>
             <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
               Like ({p.likes || 0})

--- a/pages/shorts.js
+++ b/pages/shorts.js
@@ -58,6 +58,8 @@ export default function Shorts() {
             <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
               <Avatar url={usersMap[p.userId]?.avatarUrl} size={24} />
               <Link href={`/users/${p.userId}`}>{usersMap[p.userId]?.username || 'User'}</Link>
+              <span>{new Date(p.createdAt).toLocaleString()}</span>
+              {p.location && <span>{p.location}</span>}
             </div>
             <VideoEmbed url={p.videoUrl} />
             <p className="mt-2 mb-2">{p.content}</p>

--- a/pages/trending.js
+++ b/pages/trending.js
@@ -38,6 +38,8 @@ export default function Trending() {
             <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
               <Avatar url={usersMap[p.userId]?.avatarUrl} size={24} />
               <Link href={`/users/${p.userId}`}>{usersMap[p.userId]?.username || 'User'}</Link>
+              <span>{new Date(p.createdAt).toLocaleString()}</span>
+              {p.location && <span>{p.location}</span>}
             </div>
             <VideoEmbed url={p.videoUrl} />
             <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">


### PR DESCRIPTION
## Summary
- prevent liking own posts and duplicate likes
- allow editing and deleting posts
- track likes per user via `Like` model
- add location field on posts
- display timestamps and locations across pages
- **use geolocation for post locations**

## Testing
- `npm install`
- `npm run dev` *(fails: ENETUNREACH errors but server still responds)*
- `curl -I http://localhost:3000 | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6854a25bd060832a92ffd61d2125cbf1