### PR TITLE
Combine profile routes

### DIFF
--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,92 +1,20 @@
-import { useState, useEffect } from 'react'
-import Link from 'next/link'
-import Avatar from '../components/Avatar'
-import VideoEmbed from '../components/VideoEmbed'
+import { useEffect } from 'react'
+import { useRouter } from 'next/router'
 
 export default function Profile() {
-  const [profile, setProfile] = useState(null)
-  const [avatar, setAvatar] = useState('')
-  const [posts, setPosts] = useState([])
+  const router = useRouter()
 
   useEffect(() => {
     fetch('/api/profile')
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
-        setProfile(data)
-        if (data && data.avatarUrl) {
-          setAvatar(data.avatarUrl)
-          fetch('/api/posts?userId=' + data.id)
-            .then(r => r.json())
-            .then(setPosts)
+        if (data) {
+          router.replace(`/users/${data.id}`)
+        } else {
+          router.replace('/login')
         }
       })
-  }, [])
+  }, [router])
 
-  async function save(e) {
-    e.preventDefault()
-    const res = await fetch('/api/profile', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ avatarUrl: avatar })
-    })
-    if (res.ok) {
-      setProfile({ ...profile, avatarUrl: avatar })
-    }
-  }
-
-  if (!profile) return <p className="mt-4">Please login first.</p>
-
-  return (
-    <div className="max-w-lg mx-auto mt-6 space-y-6">
-      <div className="bg-white p-6 rounded shadow text-center">
-        <Avatar url={profile.avatarUrl} size={128} />
-        <h1 className="text-2xl font-bold mt-2">{profile.username}</h1>
-      </div>
-      <form onSubmit={save} className="flex gap-2 items-center">
-        <input type="file" onChange={e => {
-          const file = e.target.files[0]
-          if (file) {
-            const reader = new FileReader()
-            reader.onload = () => setAvatar(reader.result)
-            reader.readAsDataURL(file)
-          }
-        }} className="border p-2 rounded" />
-        <button className="bg-blue-500 text-white px-4 rounded" type="submit">Save</button>
-      </form>
-      <div>
-        <h2 className="text-xl font-bold mb-2">Your Posts</h2>
-        <div className="space-y-4">
-          {posts.map(p => (
-            <div key={p.id} className="bg-white p-4 rounded shadow">
-              <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
-              <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
-                <Avatar url={profile.avatarUrl} size={24} />
-                <span>{profile.username}</span>
-                <span>{new Date(p.createdAt).toLocaleString()}</span>
-                {p.location && <span>{p.location}</span>}
-              </div>
-              {p.imageUrl && <img src={p.imageUrl} alt="" className="mt-2 max-w-full" />}
-              <VideoEmbed url={p.videoUrl} />
-              <div className="mt-2 space-x-2 text-sm">
-                <Link href={`/posts/${p.id}`}>View</Link>
-                <button
-                  onClick={async () => {
-                    const res = await fetch('/api/posts', {
-                      method: 'DELETE',
-                      headers: { 'Content-Type': 'application/json' },
-                      body: JSON.stringify({ id: p.id })
-                    })
-                    if (res.ok) setPosts(posts.filter(x => x.id !== p.id))
-                  }}
-                  className="text-red-600"
-                >
-                  Delete
-                </button>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  )
+  return <p className="mt-4">Loading...</p>
 }

--- a/pages/users/[id].js
+++ b/pages/users/[id].js
@@ -10,11 +10,17 @@ export default function UserPage() {
   const [user, setUser] = useState(null)
   const [profile, setProfile] = useState(null)
   const [posts, setPosts] = useState([])
+  const [avatar, setAvatar] = useState('')
 
   useEffect(() => {
     if (!id) return
     fetch('/api/session').then(r => r.json()).then(setUser)
-    fetch('/api/users?id=' + id).then(r => r.json()).then(setProfile)
+    fetch('/api/users?id=' + id)
+      .then(r => r.json())
+      .then(data => {
+        setProfile(data)
+        setAvatar(data.avatarUrl || '')
+      })
     fetch('/api/posts?userId=' + id).then(r => r.json()).then(setPosts)
   }, [id])
 
@@ -36,9 +42,29 @@ export default function UserPage() {
     setUser({ ...user, following: (user.following || []).filter(f => f !== Number(id)) })
   }
 
+  async function saveAvatar(e) {
+    e.preventDefault()
+    const res = await fetch('/api/profile', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ avatarUrl: avatar })
+    })
+    if (res.ok) setProfile({ ...profile, avatarUrl: avatar })
+  }
+
+  async function deletePost(postId) {
+    const res = await fetch('/api/posts', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: postId })
+    })
+    if (res.ok) setPosts(posts.filter(p => p.id !== postId))
+  }
+
   if (!profile) return <p>Loading...</p>
 
   const isFollowing = user && (user.following || []).includes(Number(id))
+  const isOwner = user && user.id === Number(id)
 
   return (
     <div>
@@ -46,22 +72,54 @@ export default function UserPage() {
         <Avatar url={profile.avatarUrl} size={48} />
         <h1 className="text-2xl font-bold">{profile.username}</h1>
       </div>
-      {user && user.id !== Number(id) && (
-        isFollowing ? (
-          <button onClick={unfollow} className="mt-2 bg-gray-300 px-2 rounded">Unfollow</button>
-        ) : (
-          <button onClick={follow} className="mt-2 bg-blue-500 text-white px-2 rounded">Follow</button>
-        )
+      {isOwner ? (
+        <form onSubmit={saveAvatar} className="mt-2 flex gap-2 items-center">
+          <input
+            type="file"
+            onChange={e => {
+              const file = e.target.files[0]
+              if (file) {
+                const reader = new FileReader()
+                reader.onload = () => setAvatar(reader.result)
+                reader.readAsDataURL(file)
+              }
+            }}
+            className="border p-2 rounded"
+          />
+          <button className="bg-blue-500 text-white px-2 rounded" type="submit">
+            Save
+          </button>
+        </form>
+      ) : (
+        user &&
+          (isFollowing ? (
+            <button onClick={unfollow} className="mt-2 bg-gray-300 px-2 rounded">
+              Unfollow
+            </button>
+          ) : (
+            <button onClick={follow} className="mt-2 bg-blue-500 text-white px-2 rounded">
+              Follow
+            </button>
+          ))
       )}
-      <div className="mt-4 grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+      <div className={isOwner ? 'mt-4 space-y-4' : 'mt-4 grid gap-4 sm:grid-cols-2 md:grid-cols-3'}>
         {posts.map(p => (
           <div key={p.id} className="bg-white p-3 rounded-lg shadow">
             <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
             <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
               <Avatar url={profile.avatarUrl} size={24} />
               <span>{profile.username}</span>
+              {isOwner && <span>{new Date(p.createdAt).toLocaleString()}</span>}
             </div>
             <VideoEmbed url={p.videoUrl} />
+            {isOwner && (
+              <div className="mt-2 space-x-2 text-sm">
+                <Link href={`/posts/${p.id}`}>View</Link>
+                <button onClick={() => deletePost(p.id)} className="text-red-600">
+                  Delete
+                </button>
+              </div>
+            )}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- redirect `/profile` to the logged in user's page
- reuse the user page for current user with avatar update and post management

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_6854a4c53508832a9aa331fc0f8707da