### PR TITLE
Auto-detect location for new posts

### DIFF
--- a/components/ComposeForm.js
+++ b/components/ComposeForm.js
@@ -20,6 +20,18 @@ export default function ComposeForm({ onPost }) {
       })
   }, [])
 
+  useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        pos => {
+          const { latitude, longitude } = pos.coords
+          setLocation(latitude.toFixed(5) + ',' + longitude.toFixed(5))
+        },
+        () => setLocation('')
+      )
+    }
+  }, [])
+
   async function createPost(e) {
     e.preventDefault()
     if (!user) return
@@ -43,7 +55,6 @@ export default function ComposeForm({ onPost }) {
       setContent('')
       setImageUrl('')
       setVideoUrl('')
-      setLocation('')
     }
   }
 
@@ -106,12 +117,6 @@ export default function ComposeForm({ onPost }) {
               }
             }}
             className="text-sm text-gray-600"
-          />
-          <input
-            value={location}
-            onChange={e => setLocation(e.target.value)}
-            placeholder="Location"
-            className="border p-1 text-sm"
           />
           <button className="bg-blue-500 text-white px-4 py-1 rounded-full" type="submit">
             Post


### PR DESCRIPTION
## Summary
- drop manual location input from `ComposeForm`
- automatically fetch geolocation on mount

## Testing
- `npm install`
- `npm run dev &` *(fails: fetch failed during Next.js startup but server became reachable)*
- `curl -I http://localhost:3003`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_6854a655e814832ab4f9cbdcad476471