### PR TITLE
Fix post timestamp and show city location

### DIFF
--- a/components/ComposeForm.js
+++ b/components/ComposeForm.js
@@ -23,9 +23,19 @@ export default function ComposeForm({ onPost }) {
   useEffect(() => {
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
-        pos => {
+        async pos => {
           const { latitude, longitude } = pos.coords
-          setLocation(latitude.toFixed(5) + ',' + longitude.toFixed(5))
+          try {
+            const res = await fetch(
+              `/api/geocode?lat=${latitude}&lon=${longitude}`
+            )
+            if (res.ok) {
+              const data = await res.json()
+              if (data.location) setLocation(data.location)
+            }
+          } catch (e) {
+            /* ignore */
+          }
         },
         () => setLocation('')
       )
@@ -41,16 +51,7 @@ export default function ComposeForm({ onPost }) {
       body: JSON.stringify({ content, imageUrl, videoUrl, location })
     })
     if (res.ok) {
-      const data = await res.json()
-      const post = {
-        id: data.id,
-        userId: user.id,
-        content,
-        imageUrl,
-        videoUrl,
-        likes: 0,
-        location
-      }
+      const post = await res.json()
       if (onPost) onPost(post)
       setContent('')
       setImageUrl('')

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@capacitor/core": "^7.4.0",
         "bcryptjs": "^2.4.3",
+        "city-reverse-geocoder": "^0.0.1",
         "iron-session": "^8.0.4",
         "next": "14.2.3",
         "react": "18.2.0",
@@ -1517,6 +1518,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/city-reverse-geocoder": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/city-reverse-geocoder/-/city-reverse-geocoder-0.0.1.tgz",
+      "integrity": "sha512-l8mA1VNdmYiFgxswrKAS5jD037Q/Yl+HwV7ijdB1hRNvMbd1d66GU7nJ9rgzftbQ4LUij2/8jlVkao9bXQKlDQ==",
+      "dependencies": {
+        "heap": "*",
+        "ngeohash": "*"
+      }
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -2352,6 +2362,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/heap": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
+      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
+      "license": "MIT"
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
@@ -3362,6 +3378,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/ngeohash": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/ngeohash/-/ngeohash-0.6.3.tgz",
+      "integrity": "sha512-kltF0cOxgx1AbmVzKxYZaoB0aj7mOxZeHaerEtQV0YaqnkXNq26WWqMmJ6lTqShYxVRWZ/mwvvTrNeOwdslWiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v0.2.0"
       }
     },
     "node_modules/node-abi": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-dom": "18.2.0",
     "sequelize": "^6.37.0",
     "sqlite3": "^5.1.6",
-    "@capacitor/core": "^7.4.0"
+    "@capacitor/core": "^7.4.0",
+    "city-reverse-geocoder": "^0.0.1"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.17",

--- a/pages/api/geocode.js
+++ b/pages/api/geocode.js
@@ -1,0 +1,14 @@
+import crg from 'city-reverse-geocoder'
+
+export default function handler(req, res) {
+  const { lat, lon } = req.query
+  if (!lat || !lon) return res.status(400).json({ error: 'Missing coordinates' })
+  try {
+    const [info] = crg(parseFloat(lat), parseFloat(lon), 1)
+    if (!info) throw new Error('no result')
+    const parts = [info.city, info.region, info.country].filter(Boolean)
+    res.status(200).json({ location: parts.join(', ') })
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to geocode location' })
+  }
+}

--- a/pages/api/posts.js
+++ b/pages/api/posts.js
@@ -50,7 +50,7 @@ async function handler(req, res) {
       videoUrl,
       location
     })
-    return res.status(201).json({ id: post.id })
+    return res.status(201).json(post)
   }
 
   if (req.method === 'PUT') {


### PR DESCRIPTION
## Summary
- geocode using offline `city-reverse-geocoder` library
- return full post details from post creation endpoint

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_6854a7687878832aacb897cc47d71b16