### PR TITLE
Enable reposts and tweak post spacing

### DIFF
--- a/components/ComposeForm.js
+++ b/components/ComposeForm.js
@@ -83,7 +83,7 @@ export default function ComposeForm({ onPost }) {
   if (!user) return null
 
   return (
-    <form onSubmit={createPost} className="mt-4 bg-white p-4 rounded-xl border flex gap-3 shadow">
+    <form onSubmit={createPost} className="mt-4 mb-6 bg-white p-4 rounded-xl border flex gap-3 shadow">
       <Avatar url={profile?.avatarUrl} size={48} />
       <div className="flex-1">
         <textarea

--- a/migrations/0006-repost.js
+++ b/migrations/0006-repost.js
@@ -1,0 +1,13 @@
+'use strict'
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Posts', 'repostId', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      references: { model: 'Posts', key: 'id' }
+    })
+  },
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Posts', 'repostId')
+  }
+}

--- a/models/post.js
+++ b/models/post.js
@@ -6,10 +6,12 @@ module.exports = (sequelize, DataTypes) => {
     imageUrl: DataTypes.STRING,
     videoUrl: DataTypes.STRING,
     location: DataTypes.STRING,
-    likes: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 }
+    likes: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+    repostId: { type: DataTypes.INTEGER, allowNull: true }
   })
   Post.associate = models => {
     Post.belongsTo(models.User, { foreignKey: 'userId' })
+    Post.belongsTo(models.Post, { foreignKey: 'repostId', as: 'repost' })
     Post.hasMany(models.Comment, { foreignKey: 'postId' })
     Post.hasMany(models.Like, { foreignKey: 'postId' })
   }

--- a/pages/api/posts.js
+++ b/pages/api/posts.js
@@ -42,7 +42,20 @@ async function handler(req, res) {
 
   if (req.method === 'POST') {
     if (!req.session.user) return res.status(401).end()
-    const { content, imageUrl, videoUrl, location } = req.body
+    const { content, imageUrl, videoUrl, location, repostId } = req.body
+    if (repostId) {
+      const orig = await Post.findByPk(repostId)
+      if (!orig) return res.status(404).end()
+      const post = await Post.create({
+        userId: req.session.user.id,
+        content: orig.content,
+        imageUrl: orig.imageUrl,
+        videoUrl: orig.videoUrl,
+        location: orig.location,
+        repostId
+      })
+      return res.status(201).json(post)
+    }
     const post = await Post.create({
       userId: req.session.user.id,
       content,

--- a/pages/home.js
+++ b/pages/home.js
@@ -29,6 +29,18 @@ export default function HomePage() {
     }
   }
 
+  async function repost(id) {
+    const res = await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repostId: id })
+    })
+    if (res.ok) {
+      const post = await res.json()
+      setPosts([post, ...posts])
+    }
+  }
+
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Home</h1>
@@ -44,9 +56,14 @@ export default function HomePage() {
               {p.location && <span>{p.location}</span>}
             </div>
             <VideoEmbed url={p.videoUrl} />
-            <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
-              {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
-            </button>
+            <div className="flex gap-2 mt-2">
+              <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
+                {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
+              </button>
+              <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded">
+                Repost
+              </button>
+            </div>
           </div>
         ))}
       </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -29,6 +29,18 @@ export default function Home() {
     }
   }
 
+  async function repost(id) {
+    const res = await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repostId: id })
+    })
+    if (res.ok) {
+      const post = await res.json()
+      setPosts([post, ...posts])
+    }
+  }
+
 
 
 
@@ -52,12 +64,20 @@ export default function Home() {
                 {p.location && <span>{p.location}</span>}
               </div>
               <VideoEmbed url={p.videoUrl} />
-              <button
-                onClick={() => like(p.id)}
-                className="bg-pink-500 text-white px-2 py-1 rounded"
-              >
-                {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
-              </button>
+              <div className="flex gap-2 mt-2">
+                <button
+                  onClick={() => like(p.id)}
+                  className="bg-pink-500 text-white px-2 py-1 rounded"
+                >
+                  {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
+                </button>
+                <button
+                  onClick={() => repost(p.id)}
+                  className="bg-green-500 text-white px-2 py-1 rounded"
+                >
+                  Repost
+                </button>
+              </div>
             </div>
           </div>
         ))}

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -64,6 +64,17 @@ export default function PostPage() {
     if (res.ok) setPost(await res.json())
   }
 
+  async function repostPost() {
+    const res = await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repostId: id })
+    })
+    if (res.ok) {
+      await res.json()
+    }
+  }
+
   if (!post) return <p>Loading...</p>
 
   return (
@@ -129,9 +140,14 @@ export default function PostPage() {
             <p className="mb-2">{post.content}</p>
             {post.imageUrl && <img src={post.imageUrl} alt="" className="mt-2 max-w-xs" />}
             <VideoEmbed url={post.videoUrl} />
-            <button onClick={likePost} className="block mt-2 bg-pink-500 text-white px-2 py-1 rounded">
-              {post.liked ? 'Unlike' : 'Like'} ({post.likes || 0})
-            </button>
+            <div className="flex gap-2 mt-2">
+              <button onClick={likePost} className="bg-pink-500 text-white px-2 py-1 rounded">
+                {post.liked ? 'Unlike' : 'Like'} ({post.likes || 0})
+              </button>
+              <button onClick={repostPost} className="bg-green-500 text-white px-2 py-1 rounded">
+                Repost
+              </button>
+            </div>
             {user && user.id === post.userId && (
               <div className="mt-2 space-x-2 text-sm">
                 <button onClick={() => setEditing(true)} className="text-blue-600">Edit</button>

--- a/pages/search.js
+++ b/pages/search.js
@@ -29,6 +29,18 @@ export default function Search() {
     }
   }
 
+  async function repost(id) {
+    const res = await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repostId: id })
+    })
+    if (res.ok) {
+      const post = await res.json()
+      setPosts([post, ...posts])
+    }
+  }
+
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Search Posts</h1>
@@ -45,9 +57,14 @@ export default function Search() {
               <span className="ml-1">{new Date(p.createdAt).toLocaleString()}</span>
               {p.location && <span className="ml-1">{p.location}</span>}
             </div>
-            <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
-              {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
-            </button>
+            <div className="flex gap-2 mt-2">
+              <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
+                {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
+              </button>
+              <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded">
+                Repost
+              </button>
+            </div>
           </div>
         ))}
       </div>

--- a/pages/shorts.js
+++ b/pages/shorts.js
@@ -49,6 +49,18 @@ export default function Shorts() {
     }
   }
 
+  async function repost(id) {
+    const res = await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repostId: id })
+    })
+    if (res.ok) {
+      const post = await res.json()
+      setPosts(p => [post, ...p])
+    }
+  }
+
   return (
     <div>
       <ComposeForm onPost={post => setPosts([post, ...posts])} />
@@ -63,9 +75,14 @@ export default function Shorts() {
             </div>
             <VideoEmbed url={p.videoUrl} />
             <p className="mt-2 mb-2">{p.content}</p>
-            <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
-              {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
-            </button>
+            <div className="flex gap-2">
+              <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
+                {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
+              </button>
+              <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded">
+                Repost
+              </button>
+            </div>
           </div>
         ))}
         <div ref={loader} className="h-6" />

--- a/pages/trending.js
+++ b/pages/trending.js
@@ -28,6 +28,18 @@ export default function Trending() {
     }
   }
 
+  async function repost(id) {
+    const res = await fetch('/api/posts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repostId: id })
+    })
+    if (res.ok) {
+      const post = await res.json()
+      setPosts([post, ...posts])
+    }
+  }
+
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Trending Posts</h1>
@@ -42,9 +54,14 @@ export default function Trending() {
               {p.location && <span>{p.location}</span>}
             </div>
             <VideoEmbed url={p.videoUrl} />
-            <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
-              {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
-            </button>
+            <div className="flex gap-2 mt-2">
+              <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
+                {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
+              </button>
+              <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded">
+                Repost
+              </button>
+            </div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- add a `repostId` column and model relationship
- allow creating posts with `repostId` in the API
- show a Repost button on feed and post pages
- space compose form from posts

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_6854aa25ce34832a89c45cfd631c6ff3