### PR TITLE
fix: block empty posts

### DIFF
--- a/pages/compose.js
+++ b/pages/compose.js
@@ -23,6 +23,7 @@ export default function Compose() {
   async function createPost(e) {
     e.preventDefault()
     if (!user) return
+    if (!content.trim()) return
     const res = await fetch('/api/posts', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- avoid submitting blank posts from the compose form

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_6854ae27e9ec832ab44ad3d023b933d4