### PR TITLE
Fix database sync race issue

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -13,9 +13,13 @@ const Like = require('./like')(sequelize, Sequelize.DataTypes)
 
 const db = { User, Post, Comment, Follow, Like, sequelize }
 
-let syncPromise
+const globalForSync = globalThis
+let syncPromise = globalForSync._syncPromise
 db.sync = () => {
-  if (!syncPromise) syncPromise = sequelize.sync({ alter: true })
+  if (!syncPromise) {
+    syncPromise = sequelize.sync({ alter: true })
+    globalForSync._syncPromise = syncPromise
+  }
   return syncPromise
 }
 


### PR DESCRIPTION
## Summary
- use `globalThis` to persist Sequelize sync across hot reloads

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_6854b020f6c0832aa2b9619c715717d1