### PR TITLE
Fix Sequelize sync issue

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -17,7 +17,7 @@ const globalForSync = globalThis
 let syncPromise = globalForSync._syncPromise
 db.sync = () => {
   if (!syncPromise) {
-    syncPromise = sequelize.sync({ alter: true })
+    syncPromise = sequelize.sync()
     globalForSync._syncPromise = syncPromise
   }
   return syncPromise


### PR DESCRIPTION
## Summary
- remove `alter` option from Sequelize sync call

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_6854d5d7edcc832abd9cac438bd255e0