### PR TITLE
Fix login error by migrating verified column

### DIFF
--- a/migrations/0007-user-verified.js
+++ b/migrations/0007-user-verified.js
@@ -1,0 +1,13 @@
+'use strict'
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Users', 'verified', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    })
+  },
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Users', 'verified')
+  }
+}


### PR DESCRIPTION
## Summary
- add missing migration for `Users.verified` field

## Testing
- `npm install`
- `npx sequelize-cli db:migrate`
- `npx sequelize-cli db:seed:all`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_6855722f7668832a85544315617fb7d0