### PR TITLE
Improve messaging features

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -22,6 +22,7 @@ export default function Layout({ children }) {
             <Link href="/home">Home</Link>
             <Link href="/trending">Trending</Link>
             <Link href="/search">Search</Link>
+            {user && <Link href="/messages">Messages</Link>}
             {user && <Link href="/compose">New Post</Link>}
             {user ? (
               <>

--- a/pages/api/messages.js
+++ b/pages/api/messages.js
@@ -33,5 +33,24 @@ export default withSessionRoute(async function handler(req, res) {
     return res.status(201).json(message)
   }
 
+  if (req.method === 'PUT') {
+    const { id } = req.query
+    const { content } = req.body
+    if (!id || !content || !content.trim()) return res.status(400).end()
+    const message = await Message.findByPk(id)
+    if (!message || message.senderId !== user.id) return res.status(403).end()
+    await message.update({ content })
+    return res.status(200).json(message)
+  }
+
+  if (req.method === 'DELETE') {
+    const { id } = req.query
+    if (!id) return res.status(400).end()
+    const message = await Message.findByPk(id)
+    if (!message || message.senderId !== user.id) return res.status(403).end()
+    await message.destroy()
+    return res.status(204).end()
+  }
+
   res.status(405).end()
 })

--- a/pages/messages/[id].js
+++ b/pages/messages/[id].js
@@ -1,17 +1,34 @@
 import { useRouter } from 'next/router'
 import { useState, useEffect } from 'react'
+import Avatar from '../../components/Avatar'
 
 export default function Conversation() {
   const router = useRouter()
   const { id } = router.query
   const [messages, setMessages] = useState([])
   const [content, setContent] = useState('')
+  const [me, setMe] = useState(null)
+  const [other, setOther] = useState(null)
+  const [editingId, setEditingId] = useState(null)
+  const [editContent, setEditContent] = useState('')
 
   useEffect(() => {
     if (!id) return
     fetch('/api/messages?userId=' + id)
       .then(r => r.json())
       .then(setMessages)
+    fetch('/api/profile')
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (!data) {
+          router.replace('/login')
+        } else {
+          setMe(data)
+        }
+      })
+    fetch('/api/users?id=' + id)
+      .then(r => r.json())
+      .then(setOther)
   }, [id])
 
   async function send() {
@@ -28,13 +45,71 @@ export default function Conversation() {
     }
   }
 
+  function startEdit(m) {
+    setEditingId(m.id)
+    setEditContent(m.content)
+  }
+
+  async function saveEdit() {
+    const res = await fetch('/api/messages?id=' + editingId, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: editContent })
+    })
+    if (res.ok) {
+      const updated = await res.json()
+      setMessages(messages.map(ms => (ms.id === updated.id ? updated : ms)))
+      setEditingId(null)
+      setEditContent('')
+    }
+  }
+
+  async function remove(id) {
+    const res = await fetch('/api/messages?id=' + id, { method: 'DELETE' })
+    if (res.ok) setMessages(messages.filter(ms => ms.id !== id))
+  }
+
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Direct Messages</h1>
       <div className="space-y-2 mb-4">
         {messages.map(m => (
           <div key={m.id} className="border p-2 rounded">
-            <p>{m.content}</p>
+            <div className="flex items-center gap-2 text-sm text-gray-600 mb-1">
+              <Avatar
+                url={m.senderId === me?.id ? me?.avatarUrl : other?.avatarUrl}
+                size={24}
+              />
+              <span>{m.senderId === me?.id ? me?.username : other?.username}</span>
+              <span>{new Date(m.createdAt).toLocaleString()}</span>
+            </div>
+            {editingId === m.id ? (
+              <div className="flex gap-2">
+                <input
+                  value={editContent}
+                  onChange={e => setEditContent(e.target.value)}
+                  className="border p-1 rounded flex-grow"
+                />
+                <button onClick={saveEdit} className="bg-blue-500 text-white px-2 rounded">
+                  Save
+                </button>
+                <button onClick={() => setEditingId(null)} className="bg-gray-300 px-2 rounded">
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <p>{m.content}</p>
+            )}
+            {m.senderId === me?.id && editingId !== m.id && (
+              <div className="mt-1 space-x-2 text-sm">
+                <button onClick={() => startEdit(m)} className="text-blue-500">
+                  Edit
+                </button>
+                <button onClick={() => remove(m.id)} className="text-red-600">
+                  Delete
+                </button>
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/pages/messages/index.js
+++ b/pages/messages/index.js
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import Link from 'next/link'
+import Avatar from '../../components/Avatar'
+
+export default function MessagesHome() {
+  const router = useRouter()
+  const [users, setUsers] = useState([])
+  const [me, setMe] = useState(null)
+
+  useEffect(() => {
+    fetch('/api/session')
+      .then(r => r.json())
+      .then(u => {
+        if (!u) {
+          router.replace('/login')
+        } else {
+          setMe(u)
+          fetch('/api/users')
+            .then(r => r.json())
+            .then(list => setUsers(list.filter(us => us.id !== u.id)))
+        }
+      })
+  }, [router])
+
+  if (!me) return <p className="mt-4">Loading...</p>
+
+  return (
+    <div>
+      <h1 className="text-2xl font-bold mb-4">Messages</h1>
+      <ul className="space-y-2">
+        {users.map(u => (
+          <li key={u.id}>
+            <Link href={`/messages/${u.id}`} className="flex items-center gap-2">
+              <Avatar url={u.avatarUrl} size={32} />
+              <span>{u.username}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Messages nav link in layout
- show conversation list at `/messages`
- support editing/deleting messages via API
- display avatars, usernames and timestamps in conversations

## Testing
- `npm install`
- `npm run dev` *(fails to fetch update info but server starts)*
- `curl -I http://localhost:3001`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_6855731cdf8c832a8c31be1b511b2256