### PR TITLE
Fix Sequelize import

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -13,7 +13,17 @@ const Like = require('./like')(sequelize, Sequelize.DataTypes)
 const Message = require('./message')(sequelize, Sequelize.DataTypes)
 const Hashtag = require('./hashtag')(sequelize, Sequelize.DataTypes)
 
-const db = { User, Post, Comment, Follow, Like, Message, Hashtag, sequelize }
+const db = {
+  Sequelize,
+  User,
+  Post,
+  Comment,
+  Follow,
+  Like,
+  Message,
+  Hashtag,
+  sequelize
+}
 
 const globalForSync = globalThis
 let syncPromise = globalForSync._syncPromise


### PR DESCRIPTION
## Summary
- export `Sequelize` from the models index so API routes can use it

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_685574891534832a93ab1deb4219486d