### PR TITLE
Increase post API body size

### DIFF
--- a/components/ComposeForm.js
+++ b/components/ComposeForm.js
@@ -28,7 +28,15 @@ export default function ComposeForm({ onPost }) {
       body: JSON.stringify({ content, imageUrl, videoUrl })
     })
     if (res.ok) {
-      const post = await res.json()
+      const data = await res.json()
+      const post = {
+        id: data.id,
+        userId: user.id,
+        content,
+        imageUrl,
+        videoUrl,
+        likes: 0
+      }
       if (onPost) onPost(post)
       setContent('')
       setImageUrl('')
@@ -60,9 +68,9 @@ export default function ComposeForm({ onPost }) {
   if (!user) return null
 
   return (
-    <form onSubmit={createPost} className="mt-4 space-y-2 bg-white p-4 rounded shadow">
-      <div className="flex gap-3">
-        <Avatar url={profile?.avatarUrl} size={48} />
+    <form onSubmit={createPost} className="mt-4 bg-white p-4 rounded-xl border flex gap-3 shadow">
+      <Avatar url={profile?.avatarUrl} size={48} />
+      <div className="flex-1">
         <textarea
           value={content}
           onChange={e => {
@@ -73,30 +81,34 @@ export default function ComposeForm({ onPost }) {
           }}
           onPaste={handlePaste}
           placeholder="What's happening?"
-          className="border p-2 w-full rounded resize-none focus:outline-none"
+          rows={3}
+          className="w-full resize-none border-none focus:ring-0 text-lg"
         />
+        {imageUrl && (
+          <img src={imageUrl} alt="preview" className="mt-3 w-full rounded-xl" />
+        )}
+        {videoUrl && (
+          <video src={videoUrl} controls className="mt-3 w-full rounded-xl" />
+        )}
+        <div className="flex items-center justify-between mt-3">
+          <input
+            type="file"
+            accept="video/*"
+            onChange={e => {
+              const file = e.target.files[0]
+              if (file) {
+                const reader = new FileReader()
+                reader.onload = () => setVideoUrl(reader.result)
+                reader.readAsDataURL(file)
+              }
+            }}
+            className="text-sm text-gray-600"
+          />
+          <button className="bg-blue-500 text-white px-4 py-1 rounded-full" type="submit">
+            Post
+          </button>
+        </div>
       </div>
-      {imageUrl && (
-        <img src={imageUrl} alt="preview" className="w-24 h-24 object-cover rounded" />
-      )}
-      {videoUrl && (
-        <video src={videoUrl} controls className="w-24 h-24 rounded" />
-      )}
-      <input
-        type="file"
-        accept="video/*"
-        onChange={e => {
-          const file = e.target.files[0]
-          if (file) {
-            const reader = new FileReader()
-            reader.onload = () => setVideoUrl(reader.result)
-            reader.readAsDataURL(file)
-          }
-        }}
-      />
-      <button className="bg-blue-600 text-white px-4 py-2 rounded" type="submit">
-        Post
-      </button>
     </form>
   )
 }

--- a/pages/api/posts.js
+++ b/pages/api/posts.js
@@ -49,7 +49,7 @@ async function handler(req, res) {
       imageUrl,
       videoUrl
     })
-    return res.status(201).json(post)
+    return res.status(201).json({ id: post.id })
   }
 
   if (req.method === 'PUT') {
@@ -77,3 +77,11 @@ async function handler(req, res) {
 }
 
 export default withSessionRoute(handler)
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '10mb'
+    }
+  }
+}

--- a/pages/compose.js
+++ b/pages/compose.js
@@ -29,8 +29,8 @@ export default function Compose() {
       body: JSON.stringify({ content, imageUrl, videoUrl })
     })
     if (res.ok) {
-      const post = await res.json()
-      router.push('/posts/' + post.id)
+      const data = await res.json()
+      router.push('/posts/' + data.id)
     }
   }
 
@@ -59,7 +59,7 @@ export default function Compose() {
 
   return (
     <div className="max-w-xl mx-auto mt-6">
-      <form onSubmit={createPost} className="bg-white rounded shadow p-4 flex gap-3">
+      <form onSubmit={createPost} className="bg-white p-4 rounded-xl border flex gap-3 shadow">
         <Avatar url={profile?.avatarUrl} size={48} />
         <div className="flex-1">
           <textarea
@@ -72,30 +72,33 @@ export default function Compose() {
             }}
             onPaste={handlePaste}
             placeholder="What's happening?"
-          className="w-full resize-none focus:outline-none border-b border-gray-300 p-2"
-        />
-        {imageUrl && (
-          <img src={imageUrl} alt="preview" className="w-32 h-32 object-cover rounded mt-2" />
-        )}
-        {videoUrl && (
-          <video src={videoUrl} controls className="w-32 h-32 rounded mt-2" />
-        )}
-        <input
-          type="file"
-          accept="video/*"
-          onChange={e => {
-            const file = e.target.files[0]
-            if (file) {
-              const reader = new FileReader()
-              reader.onload = () => setVideoUrl(reader.result)
-              reader.readAsDataURL(file)
-            }
-          }}
-          className="mt-2"
-        />
-        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded mt-3 float-right">
-          Post
-        </button>
+            rows={3}
+            className="w-full resize-none border-none focus:ring-0 text-lg"
+          />
+          {imageUrl && (
+            <img src={imageUrl} alt="preview" className="mt-3 w-full rounded-xl" />
+          )}
+          {videoUrl && (
+            <video src={videoUrl} controls className="mt-3 w-full rounded-xl" />
+          )}
+          <div className="flex items-center justify-between mt-3">
+            <input
+              type="file"
+              accept="video/*"
+              onChange={e => {
+                const file = e.target.files[0]
+                if (file) {
+                  const reader = new FileReader()
+                  reader.onload = () => setVideoUrl(reader.result)
+                  reader.readAsDataURL(file)
+                }
+              }}
+              className="text-sm text-gray-600"
+            />
+            <button type="submit" className="bg-blue-500 text-white px-4 py-1 rounded-full">
+              Post
+            </button>
+          </div>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- allow up to 10MB request bodies for posting
- trim POST response to only return the new post id
- reconstruct full post client-side
- restyle compose form to mimic Twitter

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_685479044704832abeea4fcf17369d33