### PR TITLE
Implement repost origin and counter

### DIFF
--- a/pages/home.js
+++ b/pages/home.js
@@ -56,13 +56,19 @@ export default function HomePage() {
               <span>{new Date(p.createdAt).toLocaleString()}</span>
               {p.location && <span>{p.location}</span>}
             </div>
+            {p.repostId && (
+              <p className="text-sm text-gray-500 mb-1">
+                Reposted from{' '}
+                <Link href={`/users/${p.repostUserId}`}>{usersMap[p.repostUserId]?.username || 'User'}</Link>
+              </p>
+            )}
             <VideoEmbed url={p.videoUrl} />
             <div className="flex gap-2 mt-2">
               <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
                 {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
               </button>
               <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded">
-                Repost
+                Repost ({p.repostCount || 0})
               </button>
             </div>
           </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -64,6 +64,12 @@ export default function Home() {
                 <span>{new Date(p.createdAt).toLocaleString()}</span>
                 {p.location && <span>{p.location}</span>}
               </div>
+              {p.repostId && (
+                <p className="text-sm text-gray-500 mb-1">
+                  Reposted from{' '}
+                  <Link href={`/users/${p.repostUserId}`}>{usersMap[p.repostUserId]?.username || 'User'}</Link>
+                </p>
+              )}
               <VideoEmbed url={p.videoUrl} />
               <div className="flex gap-2 mt-2">
                 <button
@@ -76,7 +82,7 @@ export default function Home() {
                   onClick={() => repost(p.id)}
                   className="bg-green-500 text-white px-2 py-1 rounded"
                 >
-                  Repost
+                  Repost ({p.repostCount || 0})
                 </button>
               </div>
             </div>

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -137,6 +137,12 @@ export default function PostPage() {
           </div>
         ) : (
           <>
+            {post.repostId && (
+              <p className="text-sm text-gray-500 mb-1">
+                Reposted from{' '}
+                <Link href={`/users/${post.repostUserId}`}>{usersMap[post.repostUserId]?.username || 'User'}</Link>
+              </p>
+            )}
             <p className="mb-2">{post.content}</p>
             {post.imageUrl && <img src={post.imageUrl} alt="" className="mt-2 max-w-xs" />}
             <VideoEmbed url={post.videoUrl} />
@@ -145,7 +151,7 @@ export default function PostPage() {
                 {post.liked ? 'Unlike' : 'Like'} ({post.likes || 0})
               </button>
               <button onClick={repostPost} className="bg-green-500 text-white px-2 py-1 rounded">
-                Repost
+                Repost ({post.repostCount || 0})
               </button>
             </div>
             {user && user.id === post.userId && (

--- a/pages/search.js
+++ b/pages/search.js
@@ -58,12 +58,18 @@ export default function Search() {
               <span className="ml-1">{new Date(p.createdAt).toLocaleString()}</span>
               {p.location && <span className="ml-1">{p.location}</span>}
             </div>
+            {p.repostId && (
+              <p className="text-sm text-gray-500 mb-1">
+                Reposted from{' '}
+                <Link href={`/users/${p.repostUserId}`}>{usersMap[p.repostUserId]?.username || 'User'}</Link>
+              </p>
+            )}
             <div className="flex gap-2 mt-2">
               <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
                 {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
               </button>
               <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded">
-                Repost
+                Repost ({p.repostCount || 0})
               </button>
             </div>
           </div>

--- a/pages/shorts.js
+++ b/pages/shorts.js
@@ -74,6 +74,12 @@ export default function Shorts() {
               <span>{new Date(p.createdAt).toLocaleString()}</span>
               {p.location && <span>{p.location}</span>}
             </div>
+            {p.repostId && (
+              <p className="text-sm text-gray-500 mb-1">
+                Reposted from{' '}
+                <Link href={`/users/${p.repostUserId}`}>{usersMap[p.repostUserId]?.username || 'User'}</Link>
+              </p>
+            )}
             <VideoEmbed url={p.videoUrl} />
             <p className="mt-2 mb-2">{p.content}</p>
             <div className="flex gap-2">
@@ -81,7 +87,7 @@ export default function Shorts() {
                 {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
               </button>
               <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded">
-                Repost
+                Repost ({p.repostCount || 0})
               </button>
             </div>
           </div>

--- a/pages/trending.js
+++ b/pages/trending.js
@@ -64,13 +64,19 @@ export default function Trending() {
               <span>{new Date(p.createdAt).toLocaleString()}</span>
               {p.location && <span>{p.location}</span>}
             </div>
+            {p.repostId && (
+              <p className="text-sm text-gray-500 mb-1">
+                Reposted from{' '}
+                <Link href={`/users/${p.repostUserId}`}>{usersMap[p.repostUserId]?.username || 'User'}</Link>
+              </p>
+            )}
             <VideoEmbed url={p.videoUrl} />
             <div className="flex gap-2 mt-2">
               <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
                 {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
               </button>
               <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded">
-                Repost
+                Repost ({p.repostCount || 0})
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- track repost origin and count in the API
- show "Reposted from" on posts
- display repost totals next to button

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_68557885d300832aac46b1bbcfebd8d9