### PR TITLE
Fix SQLite sync for new columns

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,9 +1,13 @@
 import path from 'path'
+import fs from 'fs'
 import { Sequelize } from 'sequelize'
+
+const dataDir = path.join(process.cwd(), 'data')
+if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true })
 
 const sequelize = new Sequelize({
   dialect: 'sqlite',
-  storage: path.join(process.cwd(), 'data', 'test.db'),
+  storage: path.join(dataDir, 'test.db'),
   logging: false
 })
 

--- a/models/index.js
+++ b/models/index.js
@@ -29,7 +29,7 @@ const globalForSync = globalThis
 let syncPromise = globalForSync._syncPromise
 db.sync = () => {
   if (!syncPromise) {
-    syncPromise = sequelize.sync()
+    syncPromise = sequelize.sync({ alter: true })
     globalForSync._syncPromise = syncPromise
   }
   return syncPromise


### PR DESCRIPTION
## Summary
- ensure SQLite data directory exists before connecting
- sync database with `alter: true` so new columns are added automatically

## Testing
- `npm install`
- `npm run dev &` and `curl -I http://localhost:3000`


------
https://chatgpt.com/codex/tasks/task_e_685587e7e578832a90dc7128ea128a48