### PR TITLE
Fix repost count for recommendation feed

### DIFF
--- a/pages/api/recommendations.js
+++ b/pages/api/recommendations.js
@@ -5,6 +5,13 @@ async function handler(req, res) {
   await db.sync()
   const { Post, Follow } = db
   const posts = await Post.findAll()
+  for (const p of posts) {
+    p.dataValues.repostCount = await Post.count({ where: { repostId: p.id } })
+    if (p.repostId) {
+      const orig = await Post.findByPk(p.repostId)
+      p.dataValues.repostUserId = orig ? orig.userId : null
+    }
+  }
 
   if (req.session.user) {
     const follows = await Follow.findAll({ where: { userId: req.session.user.id } })


### PR DESCRIPTION
## Summary
- compute repost count for posts in `/api/recommendations`

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_68558b2a8a64832a9dc8ab2a8c0cb0ab