### PR TITLE
Fix repost count for recommendation feed

### DIFF
--- a/lib/postHelpers.js
+++ b/lib/postHelpers.js
@@ -1,0 +1,11 @@
+export async function addRepostInfo(posts, PostModel) {
+  const arr = Array.isArray(posts) ? posts : [posts]
+  for (const p of arr) {
+    p.dataValues.repostCount = await PostModel.count({ where: { repostId: p.id } })
+    if (p.repostId) {
+      const orig = await PostModel.findByPk(p.repostId)
+      p.dataValues.repostUserId = orig ? orig.userId : null
+    }
+  }
+  return Array.isArray(posts) ? arr : arr[0]
+}

--- a/pages/api/recommendations.js
+++ b/pages/api/recommendations.js
@@ -1,10 +1,12 @@
 import { withSessionRoute } from '../../lib/session'
 import db from '../../models'
+import { addRepostInfo } from '../../lib/postHelpers'
 
 async function handler(req, res) {
   await db.sync()
   const { Post, Follow } = db
   const posts = await Post.findAll()
+  await addRepostInfo(posts, Post)
 
   if (req.session.user) {
     const follows = await Follow.findAll({ where: { userId: req.session.user.id } })


### PR DESCRIPTION
## Summary
- compute repost count for posts in `/api/recommendations`
- factor out helper to attach repost metadata to posts

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_68558b2a8a64832a9dc8ab2a8c0cb0ab