### PR TITLE
Fix sync alter loop

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -29,7 +29,7 @@ const globalForSync = globalThis
 let syncPromise = globalForSync._syncPromise
 db.sync = () => {
   if (!syncPromise) {
-    syncPromise = sequelize.sync({ alter: true })
+    syncPromise = sequelize.sync()
     globalForSync._syncPromise = syncPromise
   }
   return syncPromise


### PR DESCRIPTION
## Summary
- avoid generating Users_backup during sync by dropping `alter: true` option

## Testing
- `npm install`
- `NEXT_TELEMETRY_DISABLED=1 npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_685592bd49bc832a92162620cefd5e45