### PR TITLE
Fix repost counter update

### DIFF
--- a/pages/home.js
+++ b/pages/home.js
@@ -37,7 +37,14 @@ export default function HomePage() {
     })
     if (res.ok) {
       const post = await res.json()
-      setPosts([post, ...posts])
+      setPosts([
+        post,
+        ...posts.map(p =>
+          p.id === id
+            ? { ...p, repostCount: (p.repostCount || 0) + 1 }
+            : p
+        )
+      ])
     }
   }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -37,7 +37,14 @@ export default function Home() {
     })
     if (res.ok) {
       const post = await res.json()
-      setPosts([post, ...posts])
+      setPosts([
+        post,
+        ...posts.map(p =>
+          p.id === id
+            ? { ...p, repostCount: (p.repostCount || 0) + 1 }
+            : p
+        )
+      ])
     }
   }
 

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -72,6 +72,10 @@ export default function PostPage() {
     })
     if (res.ok) {
       await res.json()
+      setPost(p => ({
+        ...p,
+        repostCount: (p.repostCount || 0) + 1
+      }))
     }
   }
 

--- a/pages/search.js
+++ b/pages/search.js
@@ -37,7 +37,14 @@ export default function Search() {
     })
     if (res.ok) {
       const post = await res.json()
-      setPosts([post, ...posts])
+      setPosts([
+        post,
+        ...posts.map(p =>
+          p.id === id
+            ? { ...p, repostCount: (p.repostCount || 0) + 1 }
+            : p
+        )
+      ])
     }
   }
 

--- a/pages/shorts.js
+++ b/pages/shorts.js
@@ -57,7 +57,14 @@ export default function Shorts() {
     })
     if (res.ok) {
       const post = await res.json()
-      setPosts(p => [post, ...p])
+      setPosts(p => [
+        post,
+        ...p.map(x =>
+          x.id === id
+            ? { ...x, repostCount: (x.repostCount || 0) + 1 }
+            : x
+        )
+      ])
     }
   }
 

--- a/pages/trending.js
+++ b/pages/trending.js
@@ -38,7 +38,14 @@ export default function Trending() {
     })
     if (res.ok) {
       const post = await res.json()
-      setPosts([post, ...posts])
+      setPosts([
+        post,
+        ...posts.map(p =>
+          p.id === id
+            ? { ...p, repostCount: (p.repostCount || 0) + 1 }
+            : p
+        )
+      ])
     }
   }
 


### PR DESCRIPTION
## Summary
- update repost logic so counter increments immediately

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_685594b7b734832a979cb62d441a2612