### PR TITLE
Remove unused inputs in post editor

### DIFF
--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -93,24 +93,6 @@ export default function PostPage() {
               onChange={e => setFormContent(e.target.value)}
               className="border p-2 w-full"
             />
-            <input
-              value={formImage}
-              onChange={e => setFormImage(e.target.value)}
-              placeholder="Image URL"
-              className="border p-1 w-full"
-            />
-            <input
-              value={formVideo}
-              onChange={e => setFormVideo(e.target.value)}
-              placeholder="Video URL"
-              className="border p-1 w-full"
-            />
-            <input
-              value={formLocation}
-              onChange={e => setFormLocation(e.target.value)}
-              placeholder="Location"
-              className="border p-1 w-full"
-            />
             <button
               onClick={async () => {
                 const res = await fetch('/api/posts', {


### PR DESCRIPTION
## Summary
- drop image URL, video URL and location fields from the post editing form

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_685595079db8832a8aaa666e4434f116