### PR TITLE
Replace text buttons with icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@capacitor/core": "^7.4.0",
+        "@heroicons/react": "^2.2.0",
         "bcryptjs": "^2.4.3",
         "city-reverse-geocoder": "^0.0.1",
         "iron-session": "^8.0.4",
@@ -290,6 +291,15 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
+      }
     },
     "node_modules/@ionic/cli-framework-output": {
       "version": "2.2.8",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "sequelize": "^6.37.0",
     "sqlite3": "^5.1.6",
     "@capacitor/core": "^7.4.0",
-    "city-reverse-geocoder": "^0.0.1"
+    "city-reverse-geocoder": "^0.0.1",
+    "@heroicons/react": "^2.2.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.17",

--- a/pages/home.js
+++ b/pages/home.js
@@ -3,6 +3,10 @@ import Link from 'next/link'
 import Avatar from '../components/Avatar'
 import VideoEmbed from '../components/VideoEmbed'
 import ComposeForm from '../components/ComposeForm'
+import {
+  HeartIcon,
+  ArrowsRightLeftIcon
+} from '@heroicons/react/24/outline'
 
 export default function HomePage() {
   const [posts, setPosts] = useState([])
@@ -71,11 +75,13 @@ export default function HomePage() {
             )}
             <VideoEmbed url={p.videoUrl} />
             <div className="flex gap-2 mt-2">
-              <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
-                {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
+              <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded flex items-center gap-1">
+                <HeartIcon className="w-5 h-5" />
+                <span>({p.likes || 0})</span>
               </button>
-              <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded">
-                Repost ({p.repostCount || 0})
+              <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded flex items-center gap-1">
+                <ArrowsRightLeftIcon className="w-5 h-5" />
+                <span>({p.repostCount || 0})</span>
               </button>
             </div>
           </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import VideoEmbed from '../components/VideoEmbed'
 import ComposeForm from '../components/ComposeForm'
 import Avatar from '../components/Avatar'
+import { HeartIcon, ArrowsRightLeftIcon } from '@heroicons/react/24/outline'
 
 export default function Home() {
   const [posts, setPosts] = useState([])
@@ -81,15 +82,17 @@ export default function Home() {
               <div className="flex gap-2 mt-2">
                 <button
                   onClick={() => like(p.id)}
-                  className="bg-pink-500 text-white px-2 py-1 rounded"
+                  className="bg-pink-500 text-white px-2 py-1 rounded flex items-center gap-1"
                 >
-                  {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
+                  <HeartIcon className="w-5 h-5" />
+                  <span>({p.likes || 0})</span>
                 </button>
                 <button
                   onClick={() => repost(p.id)}
-                  className="bg-green-500 text-white px-2 py-1 rounded"
+                  className="bg-green-500 text-white px-2 py-1 rounded flex items-center gap-1"
                 >
-                  Repost ({p.repostCount || 0})
+                  <ArrowsRightLeftIcon className="w-5 h-5" />
+                  <span>({p.repostCount || 0})</span>
                 </button>
               </div>
             </div>

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -3,6 +3,11 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import Avatar from '../../components/Avatar'
 import VideoEmbed from '../../components/VideoEmbed'
+import {
+  HeartIcon,
+  ArrowsRightLeftIcon,
+  ChatBubbleBottomCenterTextIcon
+} from '@heroicons/react/24/outline'
 
 export default function PostPage() {
   const router = useRouter()
@@ -133,11 +138,13 @@ export default function PostPage() {
             {post.imageUrl && <img src={post.imageUrl} alt="" className="mt-2 max-w-xs" />}
             <VideoEmbed url={post.videoUrl} />
             <div className="flex gap-2 mt-2">
-              <button onClick={likePost} className="bg-pink-500 text-white px-2 py-1 rounded">
-                {post.liked ? 'Unlike' : 'Like'} ({post.likes || 0})
+              <button onClick={likePost} className="bg-pink-500 text-white px-2 py-1 rounded flex items-center gap-1">
+                <HeartIcon className="w-5 h-5" />
+                <span>({post.likes || 0})</span>
               </button>
-              <button onClick={repostPost} className="bg-green-500 text-white px-2 py-1 rounded">
-                Repost ({post.repostCount || 0})
+              <button onClick={repostPost} className="bg-green-500 text-white px-2 py-1 rounded flex items-center gap-1">
+                <ArrowsRightLeftIcon className="w-5 h-5" />
+                <span>({post.repostCount || 0})</span>
               </button>
             </div>
             {user && user.id === post.userId && (
@@ -172,7 +179,9 @@ export default function PostPage() {
                 <span>{new Date(c.createdAt).toLocaleString()}</span>
               </div>
               <p>{c.content}</p>
-              <Link href={`/thread/${c.id}`} className="text-blue-600 text-sm">Thread</Link>
+              <Link href={`/thread/${c.id}`} className="text-blue-600 text-sm inline-flex items-center">
+                <ChatBubbleBottomCenterTextIcon className="w-5 h-5" />
+              </Link>
             </div>
           </li>
         ))}

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import Link from 'next/link'
+import { HeartIcon, ArrowsRightLeftIcon } from '@heroicons/react/24/outline'
 
 export default function Search() {
   const [q, setQ] = useState('')
@@ -72,11 +73,13 @@ export default function Search() {
               </p>
             )}
             <div className="flex gap-2 mt-2">
-              <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
-                {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
+              <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded flex items-center gap-1">
+                <HeartIcon className="w-5 h-5" />
+                <span>({p.likes || 0})</span>
               </button>
-              <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded">
-                Repost ({p.repostCount || 0})
+              <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded flex items-center gap-1">
+                <ArrowsRightLeftIcon className="w-5 h-5" />
+                <span>({p.repostCount || 0})</span>
               </button>
             </div>
           </div>

--- a/pages/shorts.js
+++ b/pages/shorts.js
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import Avatar from '../components/Avatar'
 import VideoEmbed from '../components/VideoEmbed'
 import ComposeForm from '../components/ComposeForm'
+import { HeartIcon, ArrowsRightLeftIcon } from '@heroicons/react/24/outline'
 
 export default function Shorts() {
   const [posts, setPosts] = useState([])
@@ -90,11 +91,13 @@ export default function Shorts() {
             <VideoEmbed url={p.videoUrl} />
             <p className="mt-2 mb-2">{p.content}</p>
             <div className="flex gap-2">
-              <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
-                {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
+              <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded flex items-center gap-1">
+                <HeartIcon className="w-5 h-5" />
+                <span>({p.likes || 0})</span>
               </button>
-              <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded">
-                Repost ({p.repostCount || 0})
+              <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded flex items-center gap-1">
+                <ArrowsRightLeftIcon className="w-5 h-5" />
+                <span>({p.repostCount || 0})</span>
               </button>
             </div>
           </div>

--- a/pages/trending.js
+++ b/pages/trending.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import Avatar from '../components/Avatar'
 import VideoEmbed from '../components/VideoEmbed'
+import { HeartIcon, ArrowsRightLeftIcon } from '@heroicons/react/24/outline'
 
 export default function Trending() {
   const [posts, setPosts] = useState([])
@@ -79,11 +80,13 @@ export default function Trending() {
             )}
             <VideoEmbed url={p.videoUrl} />
             <div className="flex gap-2 mt-2">
-              <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded">
-                {p.liked ? 'Unlike' : 'Like'} ({p.likes || 0})
+              <button onClick={() => like(p.id)} className="bg-pink-500 text-white px-2 py-1 rounded flex items-center gap-1">
+                <HeartIcon className="w-5 h-5" />
+                <span>({p.likes || 0})</span>
               </button>
-              <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded">
-                Repost ({p.repostCount || 0})
+              <button onClick={() => repost(p.id)} className="bg-green-500 text-white px-2 py-1 rounded flex items-center gap-1">
+                <ArrowsRightLeftIcon className="w-5 h-5" />
+                <span>({p.repostCount || 0})</span>
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add Heroicons dependency
- use icon buttons for likes and reposts across pages
- change comment thread link to icon

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_6855a63231cc832a9623f2d0979b81aa