### PR TITLE
Fix nav bar overlay on video posts

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -15,7 +15,7 @@ export default function Layout({ children }) {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <header className="sticky top-0 bg-white shadow">
+      <header className="sticky top-0 bg-white shadow z-50">
         <div className="flex items-center justify-between p-4">
           <Link href="/" className="text-xl font-bold">TongXin</Link>
           <nav className="space-x-4 flex items-center">


### PR DESCRIPTION
## Summary
- set z-index on header so it stays above embedded videos

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_6855a9d20960832ab0e6c44888d87ee7