### PR TITLE
Add dark mode theme switching

### DIFF
--- a/components/ComposeForm.js
+++ b/components/ComposeForm.js
@@ -83,7 +83,7 @@ export default function ComposeForm({ onPost }) {
   if (!user) return null
 
   return (
-    <form onSubmit={createPost} className="mt-4 mb-6 bg-white p-4 rounded-xl border flex gap-3 shadow">
+    <form onSubmit={createPost} className="mt-4 mb-6 bg-white dark:bg-gray-800 p-4 rounded-xl border flex gap-3 shadow">
       <Avatar url={profile?.avatarUrl} size={48} />
       <div className="flex-1">
         <textarea

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -3,10 +3,24 @@ import Link from 'next/link'
 
 export default function Layout({ children }) {
   const [user, setUser] = useState(null)
+  const [theme, setTheme] = useState('light')
 
   useEffect(() => {
-    fetch('/api/session').then(r => r.json()).then(setUser)
+    fetch('/api/session')
+      .then(r => r.json())
+      .then(u => {
+        setUser(u)
+        if (u && u.theme) setTheme(u.theme)
+      })
   }, [])
+
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+  }, [theme])
 
   async function logout() {
     await fetch('/api/session', { method: 'DELETE' })
@@ -14,8 +28,8 @@ export default function Layout({ children }) {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="sticky top-0 bg-white shadow z-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 dark:text-gray-100">
+      <header className="sticky top-0 bg-white dark:bg-gray-800 shadow z-50">
         <div className="flex items-center justify-between p-4">
           <Link href="/" className="text-xl font-bold">TongXin</Link>
           <nav className="space-x-4 flex items-center">

--- a/migrations/0008-user-theme.js
+++ b/migrations/0008-user-theme.js
@@ -1,0 +1,13 @@
+'use strict'
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Users', 'theme', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'light'
+    })
+  },
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Users', 'theme')
+  }
+}

--- a/models/user.js
+++ b/models/user.js
@@ -4,7 +4,8 @@ module.exports = (sequelize, DataTypes) => {
     username: { type: DataTypes.STRING, unique: true, allowNull: false },
     password: { type: DataTypes.STRING, allowNull: false },
     avatarUrl: DataTypes.STRING,
-    verified: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false }
+    verified: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    theme: { type: DataTypes.STRING, allowNull: false, defaultValue: 'light' }
   })
   User.associate = models => {
     User.hasMany(models.Post, { foreignKey: 'userId' })

--- a/pages/api/profile.js
+++ b/pages/api/profile.js
@@ -9,13 +9,25 @@ export default withSessionRoute(async function handler(req, res) {
 
   if (req.method === 'GET') {
     const user = await User.findByPk(sessionUser.id)
-    return res.status(200).json({ id: user.id, username: user.username, avatarUrl: user.avatarUrl, verified: user.verified })
+    return res
+      .status(200)
+      .json({
+        id: user.id,
+        username: user.username,
+        avatarUrl: user.avatarUrl,
+        verified: user.verified,
+        theme: user.theme
+      })
   }
 
   if (req.method === 'PUT') {
-    const { avatarUrl, verified } = req.body
-    await User.update({ avatarUrl, verified }, { where: { id: sessionUser.id } })
-    return res.status(200).json({ avatarUrl, verified })
+    const { avatarUrl, verified, theme } = req.body
+    await User.update({ avatarUrl, verified, theme }, { where: { id: sessionUser.id } })
+    if (theme) {
+      req.session.user.theme = theme
+      await req.session.save()
+    }
+    return res.status(200).json({ avatarUrl, verified, theme })
   }
 
   res.status(405).end()

--- a/pages/api/session.js
+++ b/pages/api/session.js
@@ -11,9 +11,9 @@ async function handler(req, res) {
     if (!user) return res.status(401).end()
     const valid = await bcrypt.compare(password, user.password)
     if (!valid) return res.status(401).end()
-    req.session.user = { id: user.id, username: user.username }
+    req.session.user = { id: user.id, username: user.username, theme: user.theme }
     await req.session.save()
-    return res.status(200).json({ id: user.id, username: user.username })
+    return res.status(200).json({ id: user.id, username: user.username, theme: user.theme })
   } else if (req.method === 'GET') {
     res.status(200).json(req.session.user || null)
   } else if (req.method === 'DELETE') {

--- a/pages/api/users.js
+++ b/pages/api/users.js
@@ -12,7 +12,9 @@ export default async function handler(req, res) {
     if (existing) return res.status(409).end()
     const passwordHash = await bcrypt.hash(password, 10)
     const user = await User.create({ username, password: passwordHash })
-    return res.status(201).json({ id: user.id, username: user.username })
+    return res
+      .status(201)
+      .json({ id: user.id, username: user.username, theme: user.theme })
   }
 
   if (req.method === 'GET') {
@@ -27,7 +29,8 @@ export default async function handler(req, res) {
           username: user.username,
           avatarUrl: user.avatarUrl,
           verified: user.verified,
-          following: follows.map(f => f.followId)
+          following: follows.map(f => f.followId),
+          theme: user.theme
         })
     }
     const users = await User.findAll()

--- a/pages/compose.js
+++ b/pages/compose.js
@@ -60,7 +60,7 @@ export default function Compose() {
 
   return (
     <div className="max-w-xl mx-auto mt-6">
-      <form onSubmit={createPost} className="bg-white p-4 rounded-xl border flex gap-3 shadow">
+      <form onSubmit={createPost} className="bg-white dark:bg-gray-800 p-4 rounded-xl border flex gap-3 shadow">
         <Avatar url={profile?.avatarUrl} size={48} />
         <div className="flex-1">
           <textarea

--- a/pages/home.js
+++ b/pages/home.js
@@ -58,7 +58,7 @@ export default function HomePage() {
       <ComposeForm onPost={post => setPosts([post, ...posts])} />
       <div className="space-y-4">
         {posts.map(p => (
-          <div key={p.id} className="bg-white p-3 rounded-lg shadow">
+          <div key={p.id} className="bg-white dark:bg-gray-800 p-3 rounded-lg shadow">
             <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
             <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
               <Avatar url={usersMap[p.userId]?.avatarUrl} size={24} />

--- a/pages/index.js
+++ b/pages/index.js
@@ -57,7 +57,7 @@ export default function Home() {
       <ComposeForm onPost={post => setPosts([post, ...posts])} />
       <div className="space-y-4 mt-6">
         {posts.map(p => (
-          <div key={p.id} className="bg-white rounded-lg shadow overflow-hidden">
+          <div key={p.id} className="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
             {p.imageUrl && (
               <img src={p.imageUrl} alt="" className="w-full h-48 object-cover" />
             )}

--- a/pages/login.js
+++ b/pages/login.js
@@ -20,7 +20,7 @@ export default function Login() {
 
   return (
     <div className="flex justify-center mt-8">
-      <form onSubmit={login} className="space-y-3 bg-white p-6 rounded shadow w-full max-w-sm">
+      <form onSubmit={login} className="space-y-3 bg-white dark:bg-gray-800 p-6 rounded shadow w-full max-w-sm">
         <input
           value={username}
           onChange={e => setUsername(e.target.value)}

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -88,7 +88,7 @@ export default function PostPage() {
 
   return (
     <div>
-      <div className="bg-white rounded-lg shadow p-4 mt-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-4 mt-4">
         <div className="flex items-center gap-2 mb-2 text-sm text-gray-500">
           <Avatar url={usersMap[post.userId]?.avatarUrl} size={24} />
           <Link href={`/users/${post.userId}`}>{usersMap[post.userId]?.username || 'User'}</Link>
@@ -171,7 +171,7 @@ export default function PostPage() {
       <h2 className="text-xl font-bold mt-6">Comments</h2>
       <ul className="space-y-2">
         {comments.map(c => (
-          <li key={c.id} className="border p-2 rounded bg-white flex gap-2">
+          <li key={c.id} className="border p-2 rounded bg-white dark:bg-gray-800 flex gap-2">
             <Avatar url={usersMap[c.userId]?.avatarUrl} size={32} />
             <div className="flex-1">
               <div className="flex items-center gap-2 text-sm text-gray-500">

--- a/pages/register.js
+++ b/pages/register.js
@@ -25,7 +25,7 @@ export default function Register() {
 
   return (
     <div className="flex justify-center mt-8">
-      <form onSubmit={register} className="space-y-3 bg-white p-6 rounded shadow w-full max-w-sm">
+      <form onSubmit={register} className="space-y-3 bg-white dark:bg-gray-800 p-6 rounded shadow w-full max-w-sm">
         <input
           value={username}
           onChange={e => setUsername(e.target.value)}

--- a/pages/search.js
+++ b/pages/search.js
@@ -58,7 +58,7 @@ export default function Search() {
       </form>
       <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
         {posts.map(p => (
-          <div key={p.id} className="bg-white p-3 rounded-lg shadow">
+          <div key={p.id} className="bg-white dark:bg-gray-800 p-3 rounded-lg shadow">
             <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
             <div className="text-sm text-gray-500 mb-2">
               by <Link href={`/users/${p.userId}`}>{usersMap[p.userId]?.username || 'User'}</Link>

--- a/pages/shorts.js
+++ b/pages/shorts.js
@@ -74,7 +74,7 @@ export default function Shorts() {
       <ComposeForm onPost={post => setPosts([post, ...posts])} />
       <div className="space-y-6 mt-4">
         {posts.map(p => (
-          <div key={p.id} className="bg-white rounded shadow p-3">
+          <div key={p.id} className="bg-white dark:bg-gray-800 rounded shadow p-3">
             <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
               <Avatar url={usersMap[p.userId]?.avatarUrl} size={24} />
               <Link href={`/users/${p.userId}`}>{usersMap[p.userId]?.username || 'User'}</Link>

--- a/pages/thread/[id].js
+++ b/pages/thread/[id].js
@@ -44,7 +44,7 @@ export default function ThreadPage() {
   return (
     <div>
       <h1 className="text-xl font-bold mb-4">Thread</h1>
-      <div className="border p-3 rounded bg-white flex gap-2 mb-4">
+      <div className="border p-3 rounded bg-white dark:bg-gray-800 flex gap-2 mb-4">
         <Avatar url={usersMap[comment.userId]?.avatarUrl} size={32} />
         <div className="flex-1">
           <div className="flex items-center gap-2 text-sm text-gray-500">
@@ -57,7 +57,7 @@ export default function ThreadPage() {
       </div>
       <ul className="space-y-2 border-l-2 border-gray-200 pl-4">
         {replies.map(r => (
-          <li key={r.id} className="border p-2 rounded bg-white flex gap-2">
+          <li key={r.id} className="border p-2 rounded bg-white dark:bg-gray-800 flex gap-2">
             <Avatar url={usersMap[r.userId]?.avatarUrl} size={32} />
             <div className="flex-1">
               <div className="flex items-center gap-2 text-sm text-gray-500">

--- a/pages/trending.js
+++ b/pages/trending.js
@@ -63,7 +63,7 @@ export default function Trending() {
       </ul>
       <div className="space-y-4">
         {posts.map(p => (
-          <div key={p.id} className="bg-white rounded-lg shadow p-3">
+          <div key={p.id} className="bg-white dark:bg-gray-800 rounded-lg shadow p-3">
             <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
             <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
               <Avatar url={usersMap[p.userId]?.avatarUrl} size={24} />

--- a/pages/users/[id].js
+++ b/pages/users/[id].js
@@ -11,6 +11,7 @@ export default function UserPage() {
   const [profile, setProfile] = useState(null)
   const [posts, setPosts] = useState([])
   const [avatar, setAvatar] = useState('')
+  const [theme, setTheme] = useState('light')
 
   useEffect(() => {
     if (!id) return
@@ -20,6 +21,7 @@ export default function UserPage() {
       .then(data => {
         setProfile(data)
         setAvatar(data.avatarUrl || '')
+        setTheme(data.theme || 'light')
       })
     fetch('/api/posts?userId=' + id).then(r => r.json()).then(setPosts)
   }, [id])
@@ -52,6 +54,19 @@ export default function UserPage() {
     if (res.ok) setProfile({ ...profile, avatarUrl: avatar })
   }
 
+  async function saveThemePreference(e) {
+    e.preventDefault()
+    const res = await fetch('/api/profile', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ theme })
+    })
+    if (res.ok) {
+      setProfile({ ...profile, theme })
+      document.documentElement.classList.toggle('dark', theme === 'dark')
+    }
+  }
+
   async function deletePost(postId) {
     const res = await fetch('/api/posts', {
       method: 'DELETE',
@@ -74,6 +89,7 @@ export default function UserPage() {
         {profile.verified && <span className="text-blue-500">\u2713</span>}
       </div>
       {isOwner ? (
+        <>
         <form onSubmit={saveAvatar} className="mt-2 flex gap-2 items-center">
           <input
             type="file"
@@ -91,6 +107,22 @@ export default function UserPage() {
             Save
           </button>
         </form>
+        <form onSubmit={saveThemePreference} className="mt-2 flex gap-2 items-center">
+          <label htmlFor="theme" className="text-sm">Theme:</label>
+          <select
+            id="theme"
+            value={theme}
+            onChange={e => setTheme(e.target.value)}
+            className="border p-2 rounded"
+          >
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+          <button className="bg-blue-500 text-white px-2 rounded" type="submit">
+            Save
+          </button>
+        </form>
+        </>
       ) : (
         <>
           {user && (
@@ -113,7 +145,7 @@ export default function UserPage() {
       )}
       <div className={isOwner ? 'mt-4 space-y-4' : 'mt-4 grid gap-4 sm:grid-cols-2 md:grid-cols-3'}>
         {posts.map(p => (
-          <div key={p.id} className="bg-white p-3 rounded-lg shadow">
+          <div key={p.id} className="bg-white dark:bg-gray-800 p-3 rounded-lg shadow">
             <Link href={`/posts/${p.id}`} className="font-medium block mb-1">{p.content}</Link>
             <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
               <Avatar url={profile.avatarUrl} size={24} />

--- a/seeders/0001-demo.js
+++ b/seeders/0001-demo.js
@@ -12,6 +12,7 @@ module.exports = {
           username: 'test',
           password,
           avatarUrl: 'https://placekitten.com/200/200',
+          theme: 'light',
           createdAt: now,
           updatedAt: now
         }

--- a/seeders/0002-admin.js
+++ b/seeders/0002-admin.js
@@ -7,7 +7,7 @@ module.exports = {
     const now = new Date()
     await queryInterface.bulkInsert(
       'Users',
-      [{ username: 'admin', password, createdAt: now, updatedAt: now }],
+      [{ username: 'admin', password, theme: 'light', createdAt: now, updatedAt: now }],
       { ignoreDuplicates: true }
     )
     const [user] = await queryInterface.sequelize.query("SELECT id FROM Users WHERE username='admin' LIMIT 1")

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './pages/**/*.{js,jsx}',
     './components/**/*.{js,jsx}',


### PR DESCRIPTION
## Summary
- allow choosing `light` or `dark` theme per user
- persist theme in the DB and API
- apply Tailwind `dark` mode and update components
- enable theme preference editing on profile page

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_6855aaa67dbc832a83cda149375e8d3f