### PR TITLE
Fix /api/recommendations large payload

### DIFF
--- a/pages/api/recommendations.js
+++ b/pages/api/recommendations.js
@@ -5,21 +5,30 @@ import { addRepostInfo } from '../../lib/postHelpers'
 async function handler(req, res) {
   await db.sync()
   const { Post, Follow } = db
-  const posts = await Post.findAll()
-  await addRepostInfo(posts, Post)
+  const limit = parseInt(req.query.limit || '20', 10)
+  const offset = parseInt(req.query.offset || '0', 10)
+  const trending =
+    offset === 0
+      ? await Post.findAll({ order: [['likes', 'DESC']], limit: 5 })
+      : []
+  if (trending.length) await addRepostInfo(trending, Post)
 
   if (req.session.user) {
     const follows = await Follow.findAll({ where: { userId: req.session.user.id } })
     const ids = [req.session.user.id, ...follows.map(f => f.followId)]
-    const feed = posts.filter(p => ids.includes(p.userId))
-    const trending = [...posts].sort((a, b) => (b.likes || 0) - (a.likes || 0)).slice(0, 5)
+    const feed = await Post.findAll({
+      where: { userId: ids },
+      order: [['createdAt', 'DESC']],
+      offset,
+      limit
+    })
+    await addRepostInfo(feed, Post)
     const map = new Map()
     ;[...feed, ...trending].forEach(p => map.set(p.id, p))
     return res.status(200).json(Array.from(map.values()))
   }
 
-  const result = [...posts].sort((a, b) => (b.likes || 0) - (a.likes || 0)).slice(0, 5)
-  res.status(200).json(result)
+  res.status(200).json(trending)
 }
 
 export default withSessionRoute(handler)


### PR DESCRIPTION
## Summary
- avoid returning every post in `/api/recommendations`
- limit feed posts and trending query
- add pagination for infinite scrolling

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_6855ab103324832aba5555b94e15a5bf