### PR TITLE
Add spinner for infinite scroll

### DIFF
--- a/components/Spinner.js
+++ b/components/Spinner.js
@@ -1,0 +1,7 @@
+export default function Spinner() {
+  return (
+    <div className="flex justify-center py-4">
+      <div className="animate-spin rounded-full h-6 w-6 border-t-2 border-b-2 border-gray-500" />
+    </div>
+  )
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import VideoEmbed from '../components/VideoEmbed'
 import ComposeForm from '../components/ComposeForm'
 import Avatar from '../components/Avatar'
+import Spinner from '../components/Spinner'
 import { HeartIcon, ArrowsRightLeftIcon } from '@heroicons/react/24/outline'
 
 export default function Home() {
@@ -10,6 +11,7 @@ export default function Home() {
   const [usersMap, setUsersMap] = useState({})
   const [offset, setOffset] = useState(0)
   const [limit, setLimit] = useState(20)
+  const [loading, setLoading] = useState(false)
   const loader = useRef(null)
 
   useEffect(() => {
@@ -24,11 +26,17 @@ export default function Home() {
   }, [])
 
   async function load(lim = limit) {
-    const res = await fetch(`/api/recommendations?offset=${offset}&limit=${lim}`)
-    if (res.ok) {
-      const data = await res.json()
-      setPosts(p => [...p, ...data])
-      setOffset(o => o + lim)
+    if (loading) return
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/recommendations?offset=${offset}&limit=${lim}`)
+      if (res.ok) {
+        const data = await res.json()
+        setPosts(p => [...p, ...data])
+        setOffset(o => o + lim)
+      }
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -120,6 +128,7 @@ export default function Home() {
             </div>
           </div>
         ))}
+        {loading && <Spinner />}
         <div ref={loader} className="h-6" />
       </div>
     </div>

--- a/pages/shorts.js
+++ b/pages/shorts.js
@@ -4,6 +4,7 @@ import Avatar from '../components/Avatar'
 import VideoEmbed from '../components/VideoEmbed'
 import ComposeForm from '../components/ComposeForm'
 import { HeartIcon, ArrowsRightLeftIcon } from '@heroicons/react/24/outline'
+import Spinner from '../components/Spinner'
 
 export default function Shorts() {
   const [posts, setPosts] = useState([])
@@ -11,6 +12,7 @@ export default function Shorts() {
   const [offset, setOffset] = useState(0)
   const loader = useRef(null)
   const limit = 5
+  const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     fetch('/api/users').then(r => r.json()).then(list => {
@@ -22,11 +24,17 @@ export default function Shorts() {
   }, [])
 
   async function load() {
-    const res = await fetch(`/api/posts?video=1&offset=${offset}&limit=${limit}`)
-    if (res.ok) {
-      const data = await res.json()
-      setPosts(p => [...p, ...data])
-      setOffset(o => o + limit)
+    if (loading) return
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/posts?video=1&offset=${offset}&limit=${limit}`)
+      if (res.ok) {
+        const data = await res.json()
+        setPosts(p => [...p, ...data])
+        setOffset(o => o + limit)
+      }
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -102,6 +110,7 @@ export default function Shorts() {
             </div>
           </div>
         ))}
+        {loading && <Spinner />}
         <div ref={loader} className="h-6" />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add reusable `Spinner` component
- show spinner when `load` is fetching in index and shorts pages

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_6855bf8c7c6c832a80f07f3bffc5c411