### PR TITLE
Fix infinite scroll offset

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -10,6 +10,7 @@ export default function Home() {
   const [posts, setPosts] = useState([])
   const [usersMap, setUsersMap] = useState({})
   const [offset, setOffset] = useState(0)
+  const offsetRef = useRef(0)
   const [limit, setLimit] = useState(20)
   const [loading, setLoading] = useState(false)
   const loader = useRef(null)
@@ -28,17 +29,19 @@ export default function Home() {
   const load = useCallback(async (lim = limit) => {
     if (loading) return
     setLoading(true)
+    const current = offsetRef.current
+    offsetRef.current += lim
+    setOffset(offsetRef.current)
     try {
-      const res = await fetch(`/api/recommendations?offset=${offset}&limit=${lim}`)
+      const res = await fetch(`/api/recommendations?offset=${current}&limit=${lim}`)
       if (res.ok) {
         const data = await res.json()
         setPosts(p => [...p, ...data])
-        setOffset(o => o + lim)
       }
     } finally {
       setLoading(false)
     }
-  }, [loading, offset, limit])
+  }, [loading, limit])
 
   useEffect(() => {
     const obs = new IntersectionObserver(entries => {

--- a/pages/shorts.js
+++ b/pages/shorts.js
@@ -10,6 +10,7 @@ export default function Shorts() {
   const [posts, setPosts] = useState([])
   const [usersMap, setUsersMap] = useState({})
   const [offset, setOffset] = useState(0)
+  const offsetRef = useRef(0)
   const loader = useRef(null)
   const limit = 5
   const [loading, setLoading] = useState(false)
@@ -26,17 +27,19 @@ export default function Shorts() {
   const load = useCallback(async () => {
     if (loading) return
     setLoading(true)
+    const current = offsetRef.current
+    offsetRef.current += limit
+    setOffset(offsetRef.current)
     try {
-      const res = await fetch(`/api/posts?video=1&offset=${offset}&limit=${limit}`)
+      const res = await fetch(`/api/posts?video=1&offset=${current}&limit=${limit}`)
       if (res.ok) {
         const data = await res.json()
         setPosts(p => [...p, ...data])
-        setOffset(o => o + limit)
       }
     } finally {
       setLoading(false)
     }
-  }, [loading, offset, limit])
+  }, [loading, limit])
 
   useEffect(() => {
     const obs = new IntersectionObserver(entries => {


### PR DESCRIPTION
## Summary
- prevent duplicates when loading more posts

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_6855c5393820832ab680aa16e3fb82e7