### PR TITLE
Enable drag & drop for video uploads

### DIFF
--- a/components/ComposeForm.js
+++ b/components/ComposeForm.js
@@ -80,6 +80,16 @@ export default function ComposeForm({ onPost }) {
     }
   }
 
+  function handleDrop(e) {
+    e.preventDefault()
+    const file = e.dataTransfer.files[0]
+    if (file && file.type.startsWith('video/')) {
+      const reader = new FileReader()
+      reader.onload = () => setVideoUrl(reader.result)
+      reader.readAsDataURL(file)
+    }
+  }
+
   if (!user) return null
 
   return (
@@ -106,19 +116,13 @@ export default function ComposeForm({ onPost }) {
           <video src={videoUrl} controls className="mt-3 w-full rounded-xl" />
         )}
         <div className="flex items-center justify-between mt-3">
-          <input
-            type="file"
-            accept="video/*"
-            onChange={e => {
-              const file = e.target.files[0]
-              if (file) {
-                const reader = new FileReader()
-                reader.onload = () => setVideoUrl(reader.result)
-                reader.readAsDataURL(file)
-              }
-            }}
-            className="text-sm text-gray-600"
-          />
+          <div
+            onDrop={handleDrop}
+            onDragOver={e => e.preventDefault()}
+            className="flex-1 text-sm text-gray-600 border border-dashed rounded p-2 text-center mr-2"
+          >
+            Drag video here
+          </div>
           {content.trim() && (
             <button
               className="bg-blue-500 text-white px-4 py-1 rounded-full"

--- a/pages/compose.js
+++ b/pages/compose.js
@@ -56,6 +56,16 @@ export default function Compose() {
     }
   }
 
+  function handleDrop(e) {
+    e.preventDefault()
+    const file = e.dataTransfer.files[0]
+    if (file && file.type.startsWith('video/')) {
+      const reader = new FileReader()
+      reader.onload = () => setVideoUrl(reader.result)
+      reader.readAsDataURL(file)
+    }
+  }
+
   if (!user) return <p className="mt-4">Please login first.</p>
 
   return (
@@ -83,19 +93,13 @@ export default function Compose() {
             <video src={videoUrl} controls className="mt-3 w-full rounded-xl" />
           )}
           <div className="flex items-center justify-between mt-3">
-            <input
-              type="file"
-              accept="video/*"
-              onChange={e => {
-                const file = e.target.files[0]
-                if (file) {
-                  const reader = new FileReader()
-                  reader.onload = () => setVideoUrl(reader.result)
-                  reader.readAsDataURL(file)
-                }
-              }}
-              className="text-sm text-gray-600"
-            />
+            <div
+              onDrop={handleDrop}
+              onDragOver={e => e.preventDefault()}
+              className="flex-1 text-sm text-gray-600 border border-dashed rounded p-2 text-center mr-2"
+            >
+              Drag video here
+            </div>
             {content.trim() && (
               <button
                 type="submit"


### PR DESCRIPTION
## Summary
- add `handleDrop` functions for uploading videos via drag and drop
- replace `<input type="file">` elements with drop zones

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_6855cae6d548832aa37544ac4cce900b