### PR TITLE
Enable drag highlight and video upload spinner

### DIFF
--- a/components/ComposeForm.js
+++ b/components/ComposeForm.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import Avatar from './Avatar'
+import Spinner from './Spinner'
 
 export default function ComposeForm({ onPost }) {
   const [user, setUser] = useState(null)
@@ -8,6 +9,8 @@ export default function ComposeForm({ onPost }) {
   const [imageUrl, setImageUrl] = useState('')
   const [videoUrl, setVideoUrl] = useState('')
   const [location, setLocation] = useState('')
+  const [dragging, setDragging] = useState(false)
+  const [uploading, setUploading] = useState(false)
 
   useEffect(() => {
     fetch('/api/session')
@@ -80,12 +83,26 @@ export default function ComposeForm({ onPost }) {
     }
   }
 
+  function handleDragOver(e) {
+    e.preventDefault()
+    setDragging(true)
+  }
+
+  function handleDragLeave() {
+    setDragging(false)
+  }
+
   function handleDrop(e) {
     e.preventDefault()
+    setDragging(false)
     const file = e.dataTransfer.files[0]
     if (file && file.type.startsWith('video/')) {
+      setUploading(true)
       const reader = new FileReader()
-      reader.onload = () => setVideoUrl(reader.result)
+      reader.onload = () => {
+        setVideoUrl(reader.result)
+        setUploading(false)
+      }
       reader.readAsDataURL(file)
     }
   }
@@ -105,9 +122,13 @@ export default function ComposeForm({ onPost }) {
             if (m) setVideoUrl(m[0])
           }}
           onPaste={handlePaste}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onDragEnter={handleDragOver}
+          onDragLeave={handleDragLeave}
           placeholder="What's happening?"
           rows={3}
-          className="w-full resize-none border-none focus:ring-0 text-lg"
+          className={`w-full resize-none border-none focus:ring-0 text-lg ${dragging ? 'ring-2 ring-blue-400' : ''}`}
         />
         {imageUrl && (
           <img src={imageUrl} alt="preview" className="mt-3 w-full rounded-xl" />
@@ -115,14 +136,8 @@ export default function ComposeForm({ onPost }) {
         {videoUrl && (
           <video src={videoUrl} controls className="mt-3 w-full rounded-xl" />
         )}
-        <div className="flex items-center justify-between mt-3">
-          <div
-            onDrop={handleDrop}
-            onDragOver={e => e.preventDefault()}
-            className="flex-1 text-sm text-gray-600 border border-dashed rounded p-2 text-center mr-2"
-          >
-            Drag video here
-          </div>
+        {uploading && <Spinner />}
+        <div className="flex items-center justify-end mt-3">
           {content.trim() && (
             <button
               className="bg-blue-500 text-white px-4 py-1 rounded-full"


### PR DESCRIPTION
## Summary
- show highlight when dragging over compose textarea
- show spinner while video is loading

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_6855cfe6fd24832aa074b6353c23f383