### PR TITLE
Add unread message notifications

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -4,6 +4,7 @@ import Link from 'next/link'
 export default function Layout({ children }) {
   const [user, setUser] = useState(null)
   const [theme, setTheme] = useState('light')
+  const [unread, setUnread] = useState(0)
 
   useEffect(() => {
     fetch('/api/session')
@@ -22,6 +23,22 @@ export default function Layout({ children }) {
     }
   }, [theme])
 
+  useEffect(() => {
+    let timer
+    async function check() {
+      const r = await fetch('/api/unreadMessages')
+      if (r.ok) {
+        const data = await r.json()
+        setUnread(data.count)
+      }
+    }
+    if (user) {
+      check()
+      timer = setInterval(check, 10000)
+    }
+    return () => clearInterval(timer)
+  }, [user])
+
   async function logout() {
     await fetch('/api/session', { method: 'DELETE' })
     setUser(null)
@@ -36,7 +53,14 @@ export default function Layout({ children }) {
             <Link href="/home">Home</Link>
             <Link href="/trending">Trending</Link>
             <Link href="/search">Search</Link>
-            {user && <Link href="/messages">Messages</Link>}
+            {user && (
+              <Link href="/messages">
+                Messages
+                {unread > 0 && (
+                  <span className="ml-1 text-sm text-red-500">({unread})</span>
+                )}
+              </Link>
+            )}
             {user && <Link href="/compose">New Post</Link>}
             {user ? (
               <>

--- a/migrations/0009-message-read.js
+++ b/migrations/0009-message-read.js
@@ -1,0 +1,13 @@
+'use strict'
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Messages', 'read', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false
+    })
+  },
+  async down(queryInterface) {
+    await queryInterface.removeColumn('Messages', 'read')
+  }
+}

--- a/models/message.js
+++ b/models/message.js
@@ -3,7 +3,8 @@ module.exports = (sequelize, DataTypes) => {
   const Message = sequelize.define('Message', {
     senderId: { type: DataTypes.INTEGER, allowNull: false },
     receiverId: { type: DataTypes.INTEGER, allowNull: false },
-    content: { type: DataTypes.TEXT, allowNull: false }
+    content: { type: DataTypes.TEXT, allowNull: false },
+    read: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false }
   })
   Message.associate = models => {
     Message.belongsTo(models.User, { as: 'sender', foreignKey: 'senderId' })

--- a/pages/api/messages.js
+++ b/pages/api/messages.js
@@ -19,6 +19,16 @@ export default withSessionRoute(async function handler(req, res) {
       },
       order: [['createdAt', 'ASC']]
     })
+    await Message.update(
+      { read: true },
+      {
+        where: {
+          senderId: userId,
+          receiverId: user.id,
+          read: false
+        }
+      }
+    )
     return res.status(200).json(messages)
   }
 
@@ -28,7 +38,8 @@ export default withSessionRoute(async function handler(req, res) {
     const message = await Message.create({
       senderId: user.id,
       receiverId: to,
-      content
+      content,
+      read: false
     })
     return res.status(201).json(message)
   }

--- a/pages/api/unreadMessages.js
+++ b/pages/api/unreadMessages.js
@@ -1,0 +1,13 @@
+import { withSessionRoute } from '../../lib/session'
+import db from '../../models'
+
+export default withSessionRoute(async function handler(req, res) {
+  await db.sync()
+  const { Message } = db
+  const user = req.session.user
+  if (!user) return res.status(401).end()
+  const count = await Message.count({
+    where: { receiverId: user.id, read: false }
+  })
+  res.status(200).json({ count })
+})


### PR DESCRIPTION
## Summary
- track whether messages are read
- migrate to add a `read` column in Messages
- mark messages as read after fetching
- expose unread message count in new API route
- show unread count badge on Messages link

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_6855d9965c14832ab571669034ecb16f