### PR TITLE
Fix repeated API calls when fetching posts

### DIFF
--- a/pages/shorts.js
+++ b/pages/shorts.js
@@ -14,6 +14,8 @@ export default function Shorts() {
   const loader = useRef(null)
   const limit = 5
   const [loading, setLoading] = useState(false)
+  const loadingRef = useRef(false)
+  const [hasMore, setHasMore] = useState(true)
 
   useEffect(() => {
     fetch('/api/users').then(r => r.json()).then(list => {
@@ -25,7 +27,8 @@ export default function Shorts() {
   }, [])
 
   const load = useCallback(async () => {
-    if (loading) return
+    if (loadingRef.current || !hasMore) return
+    loadingRef.current = true
     setLoading(true)
     const current = offsetRef.current
     offsetRef.current += limit
@@ -35,13 +38,18 @@ export default function Shorts() {
       if (res.ok) {
         const data = await res.json()
         setPosts(p => [...p, ...data])
+        if (data.length < limit) setHasMore(false)
+      } else {
+        setHasMore(false)
       }
     } finally {
       setLoading(false)
+      loadingRef.current = false
     }
-  }, [loading, limit])
+  }, [limit, hasMore])
 
   useEffect(() => {
+    if (!hasMore) return
     const obs = new IntersectionObserver(entries => {
       if (entries[0].isIntersecting) load()
     })
@@ -51,7 +59,7 @@ export default function Shorts() {
       if (el) obs.unobserve(el)
       obs.disconnect()
     }
-  }, [load])
+  }, [load, hasMore])
 
   async function like(id) {
     const res = await fetch('/api/likes', {


### PR DESCRIPTION
## Summary
- guard against concurrent loads using a ref
- mark no more results on failed requests

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000` *(failed: 500)*
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_6855f73c01ec832a9134588521633aa1