### PR TITLE
Fix infinite fetch loop with explicit hasMore flag

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -36,9 +36,9 @@ export default function Home() {
     try {
       const res = await fetch(`/api/recommendations?offset=${current}&limit=${lim}`)
       if (res.ok) {
-        const data = await res.json()
+        const { posts: data, more } = await res.json()
         setPosts(p => [...p, ...data])
-        if (data.length < lim) setHasMore(false)
+        if (!more) setHasMore(false)
       }
     } finally {
       setLoading(false)


### PR DESCRIPTION
## Summary
- compute total post count in `recommendations` API
- return `{ posts, more }` from recommendations endpoint
- update home feed to stop when `more` is `false`

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_6855fae267cc832aa29ce05e155e7a28