### PR TITLE
Check profile existence before accessing fields

### DIFF
--- a/pages/api/profile.js
+++ b/pages/api/profile.js
@@ -9,15 +9,14 @@ export default withSessionRoute(async function handler(req, res) {
 
   if (req.method === 'GET') {
     const user = await User.findByPk(sessionUser.id)
-    return res
-      .status(200)
-      .json({
-        id: user.id,
-        username: user.username,
-        avatarUrl: user.avatarUrl,
-        verified: user.verified,
-        theme: user.theme
-      })
+    if (!user) return res.status(404).end()
+    return res.status(200).json({
+      id: user.id,
+      username: user.username,
+      avatarUrl: user.avatarUrl,
+      verified: user.verified,
+      theme: user.theme
+    })
   }
 
   if (req.method === 'PUT') {


### PR DESCRIPTION
## Summary
- handle missing user in `/api/profile`

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_6855fe89d198832abc3b3661c35001f9