### PR TITLE
Fix prod cookie auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ The seed data includes a demo administrator account:
 - **Username:** `admin`
 - **Password:** `admin123`
 
+When running a production build without HTTPS you may need to disable the
+Secure cookie flag. Set the environment variable `COOKIE_SECURE=false` (the
+default) so logins work over plain HTTP. Set it to `true` only when deploying
+behind HTTPS.
+
+Before building for production run the migrations with `NODE_ENV=production` to
+create the `data/prod.db` database:
+
+```bash
+NODE_ENV=production npx sequelize-cli db:migrate
+```
+
 This user comes with a couple of example posts so you have some content in the feed right away.
 
 Visit `http://localhost:3000` to use the app. The homepage shows your feed and recommendations. Additional pages:

--- a/config/config.js
+++ b/config/config.js
@@ -1,10 +1,17 @@
+const fs = require('fs')
+const path = require('path')
+
+// Ensure the data directory exists so migrations work in all environments
+const dataDir = path.join(__dirname, '..', 'data')
+if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true })
+
 module.exports = {
   development: {
     dialect: 'sqlite',
-    storage: 'data/test.db'
+    storage: path.join(dataDir, 'test.db')
   },
   production: {
     dialect: 'sqlite',
-    storage: 'data/prod.db'
+    storage: path.join(dataDir, 'prod.db')
   }
 }

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,7 +1,10 @@
 export const sessionOptions = {
   password: 'complex_password_at_least_32_characters_long',
   cookieName: 'tongxin_session',
-  cookieOptions: { secure: process.env.NODE_ENV === 'production' }
+  // Only set the Secure flag when explicitly enabled. In local production
+  // builds served over plain HTTP the previous NODE_ENV check prevented the
+  // cookie from being stored which caused unauthorized requests.
+  cookieOptions: { secure: process.env.COOKIE_SECURE === 'true' }
 }
 
 import { getIronSession } from 'iron-session'


### PR DESCRIPTION
## Summary
- avoid setting secure session cookie unless explicitly enabled
- document `COOKIE_SECURE` environment variable for HTTP deployments
- ensure sqlite data directory exists and add production migration instructions

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_685713b7d044832a8e8ea18ec991b737