### PR TITLE
Handle existing parent column in comment migration

### DIFF
--- a/migrations/0003-comment-parent.js
+++ b/migrations/0003-comment-parent.js
@@ -1,13 +1,19 @@
 'use strict'
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.addColumn('Comments', 'parentId', {
-      type: Sequelize.INTEGER,
-      references: { model: 'Comments', key: 'id' },
-      allowNull: true
-    })
+    const table = await queryInterface.describeTable('Comments')
+    if (!table.parentId) {
+      await queryInterface.addColumn('Comments', 'parentId', {
+        type: Sequelize.INTEGER,
+        references: { model: 'Comments', key: 'id' },
+        allowNull: true
+      })
+    }
   },
   async down(queryInterface) {
-    await queryInterface.removeColumn('Comments', 'parentId')
+    const table = await queryInterface.describeTable('Comments')
+    if (table.parentId) {
+      await queryInterface.removeColumn('Comments', 'parentId')
+    }
   }
 }


### PR DESCRIPTION
## Summary
- prevent duplicate `parentId` column when migrating comments

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_685728806814832aa4b79b8efc198722