### PR TITLE
Complete dark theme

### DIFF
--- a/components/ComposeForm.js
+++ b/components/ComposeForm.js
@@ -128,7 +128,7 @@ export default function ComposeForm({ onPost }) {
           onDragLeave={handleDragLeave}
           placeholder="What's happening?"
           rows={3}
-          className={`w-full resize-none border-none focus:ring-0 text-lg ${dragging ? 'ring-2 ring-blue-400' : ''}`}
+          className={`w-full resize-none border-none focus:ring-0 text-lg bg-white dark:bg-gray-700 dark:text-gray-100 ${dragging ? 'ring-2 ring-blue-400' : ''}`}
         />
         {imageUrl && (
           <img src={imageUrl} alt="preview" className="mt-3 w-full rounded-xl" />

--- a/pages/login.js
+++ b/pages/login.js
@@ -25,14 +25,14 @@ export default function Login() {
           value={username}
           onChange={e => setUsername(e.target.value)}
           placeholder="username"
-          className="border p-2 w-full rounded"
+          className="border p-2 w-full rounded bg-white dark:bg-gray-700 dark:text-gray-100"
         />
         <input
           type="password"
           value={password}
           onChange={e => setPassword(e.target.value)}
           placeholder="password"
-          className="border p-2 w-full rounded"
+          className="border p-2 w-full rounded bg-white dark:bg-gray-700 dark:text-gray-100"
         />
         <button className="w-full bg-blue-500 text-white py-2 rounded" type="submit">Login</button>
       </form>

--- a/pages/messages/[id].js
+++ b/pages/messages/[id].js
@@ -74,7 +74,7 @@ export default function Conversation() {
       <h1 className="text-2xl font-bold mb-4">Direct Messages</h1>
       <div className="space-y-2 mb-4">
         {messages.map(m => (
-          <div key={m.id} className="border p-2 rounded">
+          <div key={m.id} className="border p-2 rounded bg-white dark:bg-gray-800">
             <div className="flex items-center gap-2 text-sm text-gray-600 mb-1">
               <Avatar
                 url={m.senderId === me?.id ? me?.avatarUrl : other?.avatarUrl}
@@ -88,7 +88,7 @@ export default function Conversation() {
                 <input
                   value={editContent}
                   onChange={e => setEditContent(e.target.value)}
-                  className="border p-1 rounded flex-grow"
+                  className="border p-1 rounded flex-grow bg-white dark:bg-gray-700 dark:text-gray-100"
                 />
                 <button onClick={saveEdit} className="bg-blue-500 text-white px-2 rounded">
                   Save
@@ -117,7 +117,7 @@ export default function Conversation() {
         <input
           value={content}
           onChange={e => setContent(e.target.value)}
-          className="border p-2 rounded flex-grow"
+          className="border p-2 rounded flex-grow bg-white dark:bg-gray-700 dark:text-gray-100"
         />
         <button onClick={send} className="bg-blue-500 text-white px-4 rounded">
           Send

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -100,7 +100,7 @@ export default function PostPage() {
             <textarea
               value={formContent}
               onChange={e => setFormContent(e.target.value)}
-              className="border p-2 w-full"
+              className="border p-2 w-full bg-white dark:bg-gray-700 dark:text-gray-100"
             />
             <button
               onClick={async () => {
@@ -193,7 +193,7 @@ export default function PostPage() {
             onChange={e => setCommentText(e.target.value)}
             rows="3"
             placeholder="Write a comment..."
-            className="border p-2 flex-grow rounded resize-none focus:outline-none"
+            className="border p-2 flex-grow rounded resize-none focus:outline-none bg-white dark:bg-gray-700 dark:text-gray-100"
           />
           <button type="submit" className="bg-blue-500 text-white px-3 rounded">Add</button>
         </form>

--- a/pages/register.js
+++ b/pages/register.js
@@ -30,14 +30,14 @@ export default function Register() {
           value={username}
           onChange={e => setUsername(e.target.value)}
           placeholder="username"
-          className="border p-2 w-full rounded"
+          className="border p-2 w-full rounded bg-white dark:bg-gray-700 dark:text-gray-100"
         />
         <input
           type="password"
           value={password}
           onChange={e => setPassword(e.target.value)}
           placeholder="password"
-          className="border p-2 w-full rounded"
+          className="border p-2 w-full rounded bg-white dark:bg-gray-700 dark:text-gray-100"
         />
         <button className="w-full bg-green-500 text-white py-2 rounded" type="submit">Register</button>
       </form>

--- a/pages/search.js
+++ b/pages/search.js
@@ -53,7 +53,11 @@ export default function Search() {
     <div>
       <h1 className="text-2xl font-bold mb-4">Search Posts</h1>
       <form onSubmit={doSearch} className="my-4 flex gap-2">
-        <input value={q} onChange={e => setQ(e.target.value)} className="border p-1 flex-grow" />
+        <input
+          value={q}
+          onChange={e => setQ(e.target.value)}
+          className="border p-1 flex-grow rounded bg-white dark:bg-gray-700 dark:text-gray-100"
+        />
         <button className="px-3 py-1 bg-blue-500 text-white rounded" type="submit">Search</button>
       </form>
       <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">

--- a/pages/thread/[id].js
+++ b/pages/thread/[id].js
@@ -77,7 +77,7 @@ export default function ThreadPage() {
             onChange={e => setReplyText(e.target.value)}
             rows="3"
             placeholder="Write a reply..."
-            className="border p-2 flex-grow rounded resize-none focus:outline-none"
+            className="border p-2 flex-grow rounded resize-none focus:outline-none bg-white dark:bg-gray-700 dark:text-gray-100"
           />
           <button type="submit" className="bg-blue-500 text-white px-3 rounded">Reply</button>
         </form>

--- a/pages/users/[id].js
+++ b/pages/users/[id].js
@@ -101,7 +101,7 @@ export default function UserPage() {
                 reader.readAsDataURL(file)
               }
             }}
-            className="border p-2 rounded"
+            className="border p-2 rounded bg-white dark:bg-gray-700 dark:text-gray-100"
           />
           <button className="bg-blue-500 text-white px-2 rounded" type="submit">
             Save
@@ -113,7 +113,7 @@ export default function UserPage() {
             id="theme"
             value={theme}
             onChange={e => setTheme(e.target.value)}
-            className="border p-2 rounded"
+            className="border p-2 rounded bg-white dark:bg-gray-700 dark:text-gray-100"
           >
             <option value="light">Light</option>
             <option value="dark">Dark</option>


### PR DESCRIPTION
## Summary
- apply dark styles to text inputs and textareas
- add dark background for message items

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_685749ec34a8832aae561ce7600a32ec