### PR TITLE
Fix recommendation API structure

### DIFF
--- a/pages/api/recommendations.js
+++ b/pages/api/recommendations.js
@@ -34,7 +34,7 @@ async function handler(req, res) {
     return res.status(200).json({ posts, more })
   }
 
-  res.status(200).json(trending)
+  res.status(200).json({ posts: trending, more: false })
 }
 
 export default withSessionRoute(handler)


### PR DESCRIPTION
## Summary
- fix API response structure for recommendations to avoid runtime errors

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`

------
https://chatgpt.com/codex/tasks/task_e_6859bf8cc704832a80d84d622cb9e8f4