### PR TITLE
Improve API error handling

### DIFF
--- a/components/ComposeForm.js
+++ b/components/ComposeForm.js
@@ -14,11 +14,13 @@ export default function ComposeForm({ onPost }) {
 
   useEffect(() => {
     fetch('/api/session')
-      .then(r => r.json())
+      .then(r => (r.ok ? r.json() : null))
       .then(u => {
         setUser(u)
         if (u) {
-          fetch('/api/profile').then(r => r.json()).then(setProfile)
+          fetch('/api/profile')
+            .then(r => (r.ok ? r.json() : null))
+            .then(setProfile)
         }
       })
   }, [])

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -7,7 +7,7 @@ export default function Layout({ children }) {
 
   useEffect(() => {
     fetch('/api/session')
-      .then(r => r.json())
+      .then(r => (r.ok ? r.json() : null))
       .then(u => setUser(u))
   }, [])
 

--- a/models/index.js
+++ b/models/index.js
@@ -6,6 +6,7 @@ const dbFile = process.env.NODE_ENV === 'production'
   ? path.join(process.cwd(), 'data', 'prod.db')
   : path.join(process.cwd(), 'data', 'test.db')
 
+console.log('Using SQLite file', dbFile)
 const sequelize = new Sequelize({ dialect: 'sqlite', storage: dbFile })
 
 const User = require('./user')(sequelize, Sequelize.DataTypes)

--- a/pages/home.js
+++ b/pages/home.js
@@ -13,12 +13,16 @@ export default function HomePage() {
   const [usersMap, setUsersMap] = useState({})
 
   useEffect(() => {
-    fetch('/api/posts?feed=1').then(r => r.json()).then(setPosts)
-    fetch('/api/users').then(r => r.json()).then(list => {
-      const m = {}
-      list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl, verified: u.verified }))
-      setUsersMap(m)
-    })
+    fetch('/api/posts?feed=1')
+      .then(r => (r.ok ? r.json() : []))
+      .then(setPosts)
+    fetch('/api/users')
+      .then(r => (r.ok ? r.json() : []))
+      .then(list => {
+        const m = {}
+        list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl, verified: u.verified }))
+        setUsersMap(m)
+      })
   }, [])
 
   async function like(id) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -20,11 +20,13 @@ export default function Home() {
     const initial = window.innerHeight < 800 ? 10 : 20
     setLimit(initial)
     load(initial)
-    fetch('/api/users').then(r => r.json()).then(list => {
-      const m = {}
-      list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl, verified: u.verified }))
-      setUsersMap(m)
-    })
+    fetch('/api/users')
+      .then(r => (r.ok ? r.json() : []))
+      .then(list => {
+        const m = {}
+        list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl, verified: u.verified }))
+        setUsersMap(m)
+      })
   }, [])
 
   const load = useCallback(async (lim = limit) => {

--- a/pages/messages/[id].js
+++ b/pages/messages/[id].js
@@ -15,7 +15,7 @@ export default function Conversation() {
   useEffect(() => {
     if (!id) return
     fetch('/api/messages?userId=' + id)
-      .then(r => r.json())
+      .then(r => (r.ok ? r.json() : []))
       .then(setMessages)
     fetch('/api/profile')
       .then(r => (r.ok ? r.json() : null))
@@ -27,7 +27,7 @@ export default function Conversation() {
         }
       })
     fetch('/api/users?id=' + id)
-      .then(r => r.json())
+      .then(r => (r.ok ? r.json() : null))
       .then(setOther)
   }, [id])
 

--- a/pages/messages/index.js
+++ b/pages/messages/index.js
@@ -10,14 +10,14 @@ export default function MessagesHome() {
 
   useEffect(() => {
     fetch('/api/session')
-      .then(r => r.json())
+      .then(r => (r.ok ? r.json() : null))
       .then(u => {
         if (!u) {
           router.replace('/login')
         } else {
           setMe(u)
           fetch('/api/users')
-            .then(r => r.json())
+            .then(r => (r.ok ? r.json() : []))
             .then(list => setUsers(list.filter(us => us.id !== u.id)))
         }
       })

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -26,7 +26,7 @@ export default function PostPage() {
   useEffect(() => {
     if (!id) return
     fetch('/api/posts?id=' + id)
-      .then(r => r.json())
+      .then(r => (r.ok ? r.json() : null))
       .then(p => {
         setPost(p)
         setFormContent(p.content || '')
@@ -35,14 +35,18 @@ export default function PostPage() {
         setFormLocation(p.location || '')
       })
     fetch('/api/comments?postId=' + id + '&parentId=null')
-      .then(r => r.json())
+      .then(r => (r.ok ? r.json() : []))
       .then(setComments)
-    fetch('/api/session').then(r => r.json()).then(setUser)
-    fetch('/api/users').then(r => r.json()).then(list => {
-      const m = {}
-      list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl }))
-      setUsersMap(m)
-    })
+    fetch('/api/session')
+      .then(r => (r.ok ? r.json() : null))
+      .then(setUser)
+    fetch('/api/users')
+      .then(r => (r.ok ? r.json() : []))
+      .then(list => {
+        const m = {}
+        list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl }))
+        setUsersMap(m)
+      })
   }, [id])
 
   async function addComment(e) {

--- a/pages/search.js
+++ b/pages/search.js
@@ -10,12 +10,14 @@ export default function Search() {
   async function doSearch(e) {
     e.preventDefault()
     const res = await fetch('/api/posts?q=' + encodeURIComponent(q))
-    setPosts(await res.json())
-    fetch('/api/users').then(r => r.json()).then(list => {
-      const m = {}
-      list.forEach(u => (m[u.id] = { username: u.username, verified: u.verified }))
-      setUsersMap(m)
-    })
+    if (res.ok) setPosts(await res.json())
+    fetch('/api/users')
+      .then(r => (r.ok ? r.json() : []))
+      .then(list => {
+        const m = {}
+        list.forEach(u => (m[u.id] = { username: u.username, verified: u.verified }))
+        setUsersMap(m)
+      })
   }
 
   async function like(id) {

--- a/pages/shorts.js
+++ b/pages/shorts.js
@@ -17,11 +17,13 @@ export default function Shorts() {
   const [hasMore, setHasMore] = useState(true)
 
   useEffect(() => {
-    fetch('/api/users').then(r => r.json()).then(list => {
-      const m = {}
-      list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl, verified: u.verified }))
-      setUsersMap(m)
-    })
+    fetch('/api/users')
+      .then(r => (r.ok ? r.json() : []))
+      .then(list => {
+        const m = {}
+        list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl, verified: u.verified }))
+        setUsersMap(m)
+      })
     load()
   }, [])
 

--- a/pages/thread/[id].js
+++ b/pages/thread/[id].js
@@ -14,14 +14,22 @@ export default function ThreadPage() {
 
   useEffect(() => {
     if (!id) return
-    fetch('/api/comments?id=' + id).then(r => r.json()).then(setComment)
-    fetch('/api/comments?parentId=' + id).then(r => r.json()).then(setReplies)
-    fetch('/api/session').then(r => r.json()).then(setUser)
-    fetch('/api/users').then(r => r.json()).then(list => {
-      const m = {}
-      list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl, verified: u.verified }))
-      setUsersMap(m)
-    })
+    fetch('/api/comments?id=' + id)
+      .then(r => (r.ok ? r.json() : null))
+      .then(setComment)
+    fetch('/api/comments?parentId=' + id)
+      .then(r => (r.ok ? r.json() : []))
+      .then(setReplies)
+    fetch('/api/session')
+      .then(r => (r.ok ? r.json() : null))
+      .then(setUser)
+    fetch('/api/users')
+      .then(r => (r.ok ? r.json() : []))
+      .then(list => {
+        const m = {}
+        list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl, verified: u.verified }))
+        setUsersMap(m)
+      })
   }, [id])
 
   async function addReply(e) {

--- a/pages/trending.js
+++ b/pages/trending.js
@@ -10,13 +10,19 @@ export default function Trending() {
   const [tags, setTags] = useState([])
 
   useEffect(() => {
-    fetch('/api/posts?trending=1').then(r => r.json()).then(setPosts)
-    fetch('/api/users').then(r => r.json()).then(list => {
-      const m = {}
-      list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl, verified: u.verified }))
-      setUsersMap(m)
-    })
-    fetch('/api/hashtags').then(r => r.json()).then(setTags)
+    fetch('/api/posts?trending=1')
+      .then(r => (r.ok ? r.json() : []))
+      .then(setPosts)
+    fetch('/api/users')
+      .then(r => (r.ok ? r.json() : []))
+      .then(list => {
+        const m = {}
+        list.forEach(u => (m[u.id] = { username: u.username, avatarUrl: u.avatarUrl, verified: u.verified }))
+        setUsersMap(m)
+      })
+    fetch('/api/hashtags')
+      .then(r => (r.ok ? r.json() : []))
+      .then(setTags)
   }, [])
 
   async function like(id) {

--- a/pages/users/[id].js
+++ b/pages/users/[id].js
@@ -14,14 +14,18 @@ export default function UserPage() {
 
   useEffect(() => {
     if (!id) return
-    fetch('/api/session').then(r => r.json()).then(setUser)
+    fetch('/api/session')
+      .then(r => (r.ok ? r.json() : null))
+      .then(setUser)
     fetch('/api/users?id=' + id)
-      .then(r => r.json())
+      .then(r => (r.ok ? r.json() : null))
       .then(data => {
         setProfile(data)
         setAvatar(data.avatarUrl || '')
       })
-    fetch('/api/posts?userId=' + id).then(r => r.json()).then(setPosts)
+    fetch('/api/posts?userId=' + id)
+      .then(r => (r.ok ? r.json() : []))
+      .then(setPosts)
   }, [id])
 
   async function follow() {


### PR DESCRIPTION
## Summary
- return null or empty values when API calls fail
- log which SQLite file is used

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_6859c0c70984832abc30d88068e7e9bc