### PR TITLE
Fix geolocation call for anonymous users

### DIFF
--- a/components/ComposeForm.js
+++ b/components/ComposeForm.js
@@ -26,26 +26,25 @@ export default function ComposeForm({ onPost }) {
   }, [])
 
   useEffect(() => {
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        async pos => {
-          const { latitude, longitude } = pos.coords
-          try {
-            const res = await fetch(
-              `/api/geocode?lat=${latitude}&lon=${longitude}`
-            )
-            if (res.ok) {
-              const data = await res.json()
-              if (data.location) setLocation(data.location)
-            }
-          } catch (e) {
-            /* ignore */
+    if (!user || !navigator.geolocation) return
+    navigator.geolocation.getCurrentPosition(
+      async pos => {
+        const { latitude, longitude } = pos.coords
+        try {
+          const res = await fetch(
+            `/api/geocode?lat=${latitude}&lon=${longitude}`
+          )
+          if (res.ok) {
+            const data = await res.json()
+            if (data.location) setLocation(data.location)
           }
-        },
-        () => setLocation('')
-      )
-    }
-  }, [])
+        } catch (e) {
+          /* ignore */
+        }
+      },
+      () => setLocation('')
+    )
+  }, [user])
 
   async function createPost(e) {
     e.preventDefault()


### PR DESCRIPTION
## Summary
- trigger geolocation lookup only after login in `ComposeForm`

## Testing
- `npm run dev` *(fails: ENETUNREACH while fetching version info)*
- `curl -I http://localhost:3000`


------
https://chatgpt.com/codex/tasks/task_e_6859c483e5a8832a94731db1d99789a7