### PR TITLE
Fix geocode handler for unexpected returns

### DIFF
--- a/pages/api/geocode.js
+++ b/pages/api/geocode.js
@@ -4,7 +4,8 @@ export default function handler(req, res) {
   const { lat, lon } = req.query
   if (!lat || !lon) return res.status(400).json({ error: 'Missing coordinates' })
   try {
-    const [info] = crg(parseFloat(lat), parseFloat(lon), 1)
+    const result = crg(parseFloat(lat), parseFloat(lon), 1)
+    const info = Array.isArray(result) ? result[0] : result
     if (!info) throw new Error('no result')
     const parts = [info.city, info.region, info.country].filter(Boolean)
     res.status(200).json({ location: parts.join(', ') })


### PR DESCRIPTION
## Summary
- handle non-array results from `city-reverse-geocoder`

## Testing
- `npm install`
- `npm run dev &`
- `curl -I http://localhost:3000`
- `pkill -f "next dev"`


------
https://chatgpt.com/codex/tasks/task_e_6859c73ce5dc832a97fa2b3a9060d0c0